### PR TITLE
feat: Implement a memoization-based cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "ahash"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+dependencies = [
+ "cfg-if",
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -387,6 +399,7 @@ dependencies = [
  "libipld",
  "libipld-core",
  "proptest",
+ "quick_cache",
  "roaring-graphs",
  "serde",
  "serde_ipld_dagcbor",
@@ -698,6 +711,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
 name = "errno"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -908,6 +927,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
+name = "hashbrown"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -952,7 +977,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -1147,6 +1172,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
+name = "lock_api"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1297,6 +1332,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14f2252c834a40ed9bb5422029649578e63aa341ac401f74e719dd1afda8394e"
 
 [[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1406,6 +1464,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d6da84cc204722a989e01ba2f6e1e276e190f22263d0cb6ce8526fcdb0d2e1f"
 dependencies = [
  "byteorder",
+]
+
+[[package]]
+name = "quick_cache"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f69f8d22fa3f34f3083d9a4375c038732c7a7e964de1beb81c544da92dfc40b8"
+dependencies = [
+ "ahash",
+ "equivalent",
+ "hashbrown 0.14.0",
+ "parking_lot",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -392,6 +392,7 @@ dependencies = [
  "serde_ipld_dagcbor",
  "test-strategy",
  "thiserror",
+ "tokio",
  "tracing",
  "tracing-subscriber",
  "wnfs-common",

--- a/car-mirror-benches/Cargo.toml
+++ b/car-mirror-benches/Cargo.toml
@@ -10,7 +10,7 @@ anyhow = "1.0"
 async-std = { version = "1.11", features = ["attributes"] }
 async-trait = "0.1"
 bytes = "1.4.0"
-car-mirror = { path = "../car-mirror", version = "0.1", features = ["test_utils"] }
+car-mirror = { path = "../car-mirror", version = "0.1", features = ["test_utils", "quick_cache"] }
 libipld = "0.16.0"
 wnfs-common = "0.1.23"
 

--- a/car-mirror-benches/benches/artificially_slow_blockstore.rs
+++ b/car-mirror-benches/benches/artificially_slow_blockstore.rs
@@ -5,6 +5,7 @@ use car_mirror::{
     common::Config,
     pull, push,
     test_utils::{arb_ipld_dag, links_to_padded_ipld, setup_blockstore},
+    traits::InMemoryCache,
 };
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use libipld::Cid;
@@ -27,19 +28,26 @@ pub fn push_throttled(c: &mut Criterion) {
             },
             |(client_store, root)| {
                 let client_store = &ThrottledBlockStore(client_store);
+                let client_cache = &InMemoryCache::new(10_000);
                 let server_store = &ThrottledBlockStore::new();
+                let server_cache = &InMemoryCache::new(10_000);
                 let config = &Config::default();
 
                 // Simulate a multi-round protocol run in-memory
                 async_std::task::block_on(async move {
-                    let mut request = push::request(root, None, config, client_store).await?;
+                    let mut request =
+                        push::request(root, None, config, client_store, client_cache).await?;
                     loop {
-                        let response = push::response(root, request, config, server_store).await?;
+                        let response =
+                            push::response(root, request, config, server_store, server_cache)
+                                .await?;
 
                         if response.indicates_finished() {
                             break;
                         }
-                        request = push::request(root, Some(response), config, client_store).await?;
+                        request =
+                            push::request(root, Some(response), config, client_store, client_cache)
+                                .await?;
                     }
 
                     Ok::<(), anyhow::Error>(())
@@ -67,15 +75,22 @@ pub fn pull_throttled(c: &mut Criterion) {
             },
             |(server_store, root)| {
                 let server_store = &ThrottledBlockStore(server_store);
+                let server_cache = &InMemoryCache::new(10_000);
                 let client_store = &ThrottledBlockStore::new();
+                let client_cache = &InMemoryCache::new(10_000);
                 let config = &Config::default();
 
                 // Simulate a multi-round protocol run in-memory
                 async_std::task::block_on(async move {
-                    let mut request = pull::request(root, None, config, client_store).await?;
+                    let mut request =
+                        pull::request(root, None, config, client_store, client_cache).await?;
                     loop {
-                        let response = pull::response(root, request, config, server_store).await?;
-                        request = pull::request(root, Some(response), config, client_store).await?;
+                        let response =
+                            pull::response(root, request, config, server_store, server_cache)
+                                .await?;
+                        request =
+                            pull::request(root, Some(response), config, client_store, client_cache)
+                                .await?;
 
                         if request.indicates_finished() {
                             break;

--- a/car-mirror-benches/benches/in_memory.rs
+++ b/car-mirror-benches/benches/in_memory.rs
@@ -2,6 +2,7 @@ use car_mirror::{
     common::Config,
     pull, push,
     test_utils::{arb_ipld_dag, links_to_padded_ipld, setup_blockstore},
+    traits::InMemoryCache,
 };
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use wnfs_common::MemoryBlockStore;
@@ -21,19 +22,26 @@ pub fn push(c: &mut Criterion) {
                 (store, root)
             },
             |(ref client_store, root)| {
+                let client_cache = &InMemoryCache::new(10_000);
                 let server_store = &MemoryBlockStore::new();
+                let server_cache = &InMemoryCache::new(10_000);
                 let config = &Config::default();
 
                 // Simulate a multi-round protocol run in-memory
                 async_std::task::block_on(async move {
-                    let mut request = push::request(root, None, config, client_store).await?;
+                    let mut request =
+                        push::request(root, None, config, client_store, client_cache).await?;
                     loop {
-                        let response = push::response(root, request, config, server_store).await?;
+                        let response =
+                            push::response(root, request, config, server_store, server_cache)
+                                .await?;
 
                         if response.indicates_finished() {
                             break;
                         }
-                        request = push::request(root, Some(response), config, client_store).await?;
+                        request =
+                            push::request(root, Some(response), config, client_store, client_cache)
+                                .await?;
                     }
 
                     Ok::<(), anyhow::Error>(())
@@ -60,15 +68,22 @@ pub fn pull(c: &mut Criterion) {
                 (store, root)
             },
             |(ref server_store, root)| {
+                let server_cache = &InMemoryCache::new(10_000);
                 let client_store = &MemoryBlockStore::new();
+                let client_cache = &InMemoryCache::new(10_000);
                 let config = &Config::default();
 
                 // Simulate a multi-round protocol run in-memory
                 async_std::task::block_on(async move {
-                    let mut request = pull::request(root, None, config, client_store).await?;
+                    let mut request =
+                        pull::request(root, None, config, client_store, client_cache).await?;
                     loop {
-                        let response = pull::response(root, request, config, server_store).await?;
-                        request = pull::request(root, Some(response), config, client_store).await?;
+                        let response =
+                            pull::response(root, request, config, server_store, server_cache)
+                                .await?;
+                        request =
+                            pull::request(root, Some(response), config, client_store, client_cache)
+                                .await?;
 
                         if request.indicates_finished() {
                             break;

--- a/car-mirror/Cargo.toml
+++ b/car-mirror/Cargo.toml
@@ -33,6 +33,7 @@ iroh-car = "0.3.0"
 libipld = "0.16.0"
 libipld-core = "0.16.0"
 proptest = { version = "1.1", optional = true }
+quick_cache = "0.4.0"
 roaring-graphs = { version = "0.12", optional = true }
 serde = "1.0.183"
 serde_ipld_dagcbor = "0.4.0"

--- a/car-mirror/Cargo.toml
+++ b/car-mirror/Cargo.toml
@@ -37,6 +37,7 @@ roaring-graphs = { version = "0.12", optional = true }
 serde = "1.0.183"
 serde_ipld_dagcbor = "0.4.0"
 thiserror = "1.0.47"
+tokio = { version = "^1", default-features = false }
 tracing = "0.1"
 tracing-subscriber = "0.3"
 wnfs-common = "0.1.23"

--- a/car-mirror/Cargo.toml
+++ b/car-mirror/Cargo.toml
@@ -33,7 +33,7 @@ iroh-car = "0.3.0"
 libipld = "0.16.0"
 libipld-core = "0.16.0"
 proptest = { version = "1.1", optional = true }
-quick_cache = "0.4.0"
+quick_cache = { version = "0.4.0", optional = true }
 roaring-graphs = { version = "0.12", optional = true }
 serde = "1.0.183"
 serde_ipld_dagcbor = "0.4.0"
@@ -53,6 +53,7 @@ test-strategy = "0.3"
 [features]
 default = []
 test_utils = ["proptest", "roaring-graphs"]
+quick_cache = ["dep:quick_cache"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/car-mirror/src/dag_walk.rs
+++ b/car-mirror/src/dag_walk.rs
@@ -160,7 +160,7 @@ mod tests {
             .await?;
 
         let cids = DagWalk::breadth_first([cid_root])
-            .stream(store, &NoCache())
+            .stream(store, &NoCache)
             .try_collect::<Vec<_>>()
             .await?
             .into_iter()
@@ -213,7 +213,7 @@ mod proptests {
             }
 
             let mut cids = DagWalk::breadth_first([root])
-                .stream(store, &NoCache())
+                .stream(store, &NoCache)
                 .try_collect::<Vec<_>>()
                 .await
                 .unwrap();

--- a/car-mirror/src/incremental_verification.rs
+++ b/car-mirror/src/incremental_verification.rs
@@ -68,7 +68,7 @@ impl IncrementalDagVerification {
                     }
                 }
                 Err(e) => return Err(e),
-                Ok(Some((cid, _))) => {
+                Ok(Some(cid)) => {
                     self.want_cids.remove(&cid);
                     self.have_cids.insert(cid);
                 }

--- a/car-mirror/src/lib.rs
+++ b/car-mirror/src/lib.rs
@@ -23,3 +23,5 @@ pub mod messages;
 pub mod pull;
 /// The CAR mirror push protocol. Meant to be used qualified, i.e. `push::request` and `push::response`
 pub mod push;
+/// Traits defined in this crate
+pub mod traits;

--- a/car-mirror/src/pull.rs
+++ b/car-mirror/src/pull.rs
@@ -89,12 +89,10 @@ mod tests {
         // client should have all data
         let client_cids = DagWalk::breadth_first([root])
             .stream(client_store)
-            .map_ok(|(cid, _)| cid)
             .try_collect::<HashSet<_>>()
             .await?;
         let server_cids = DagWalk::breadth_first([root])
             .stream(server_store)
-            .map_ok(|(cid, _)| cid)
             .try_collect::<HashSet<_>>()
             .await?;
 
@@ -136,13 +134,11 @@ mod proptests {
             // client should have all data
             let client_cids = DagWalk::breadth_first([root])
                 .stream(client_store)
-                .map_ok(|(cid, _)| cid)
                 .try_collect::<HashSet<_>>()
                 .await
                 .unwrap();
             let server_cids = DagWalk::breadth_first([root])
                 .stream(server_store)
-                .map_ok(|(cid, _)| cid)
                 .try_collect::<HashSet<_>>()
                 .await
                 .unwrap();

--- a/car-mirror/src/pull.rs
+++ b/car-mirror/src/pull.rs
@@ -63,12 +63,11 @@ mod tests {
         server_store: &MemoryBlockStore,
     ) -> Result<Vec<Metrics>> {
         let mut metrics = Vec::new();
-        let mut request =
-            crate::pull::request(root, None, config, client_store, &NoCache()).await?;
+        let mut request = crate::pull::request(root, None, config, client_store, &NoCache).await?;
         loop {
             let request_bytes = serde_ipld_dagcbor::to_vec(&request)?.len();
             let response =
-                crate::pull::response(root, request, config, server_store, &NoCache()).await?;
+                crate::pull::response(root, request, config, server_store, &NoCache).await?;
             let response_bytes = response.bytes.len();
 
             metrics.push(Metrics {
@@ -76,8 +75,8 @@ mod tests {
                 response_bytes,
             });
 
-            request = crate::pull::request(root, Some(response), config, client_store, &NoCache())
-                .await?;
+            request =
+                crate::pull::request(root, Some(response), config, client_store, &NoCache).await?;
             if request.indicates_finished() {
                 break;
             }
@@ -95,11 +94,11 @@ mod tests {
 
         // client should have all data
         let client_cids = DagWalk::breadth_first([root])
-            .stream(client_store, &NoCache())
+            .stream(client_store, &NoCache)
             .try_collect::<HashSet<_>>()
             .await?;
         let server_cids = DagWalk::breadth_first([root])
-            .stream(server_store, &NoCache())
+            .stream(server_store, &NoCache)
             .try_collect::<HashSet<_>>()
             .await?;
 
@@ -141,12 +140,12 @@ mod proptests {
 
             // client should have all data
             let client_cids = DagWalk::breadth_first([root])
-                .stream(client_store, &NoCache())
+                .stream(client_store, &NoCache)
                 .try_collect::<HashSet<_>>()
                 .await
                 .unwrap();
             let server_cids = DagWalk::breadth_first([root])
-                .stream(server_store, &NoCache())
+                .stream(server_store, &NoCache)
                 .try_collect::<HashSet<_>>()
                 .await
                 .unwrap();

--- a/car-mirror/src/pull.rs
+++ b/car-mirror/src/pull.rs
@@ -2,6 +2,7 @@ use crate::{
     common::{block_receive, block_send, CarFile, Config, ReceiverState},
     error::Error,
     messages::PullRequest,
+    traits::Cache,
 };
 use libipld::Cid;
 use wnfs_common::BlockStore;
@@ -22,8 +23,9 @@ pub async fn request(
     last_response: Option<CarFile>,
     config: &Config,
     store: &impl BlockStore,
+    cache: &impl Cache,
 ) -> Result<PullRequest, Error> {
-    Ok(block_receive(root, last_response, config, store)
+    Ok(block_receive(root, last_response, config, store, cache)
         .await?
         .into())
 }
@@ -34,9 +36,10 @@ pub async fn response(
     request: PullRequest,
     config: &Config,
     store: &impl BlockStore,
+    cache: &impl Cache,
 ) -> Result<CarFile, Error> {
     let receiver_state = Some(ReceiverState::from(request));
-    block_send(root, receiver_state, config, store).await
+    block_send(root, receiver_state, config, store, cache).await
 }
 
 #[cfg(test)]
@@ -45,6 +48,7 @@ mod tests {
         common::Config,
         dag_walk::DagWalk,
         test_utils::{setup_random_dag, Metrics},
+        traits::NoCache,
     };
     use anyhow::Result;
     use futures::TryStreamExt;
@@ -59,10 +63,12 @@ mod tests {
         server_store: &MemoryBlockStore,
     ) -> Result<Vec<Metrics>> {
         let mut metrics = Vec::new();
-        let mut request = crate::pull::request(root, None, config, client_store).await?;
+        let mut request =
+            crate::pull::request(root, None, config, client_store, &NoCache()).await?;
         loop {
             let request_bytes = serde_ipld_dagcbor::to_vec(&request)?.len();
-            let response = crate::pull::response(root, request, config, server_store).await?;
+            let response =
+                crate::pull::response(root, request, config, server_store, &NoCache()).await?;
             let response_bytes = response.bytes.len();
 
             metrics.push(Metrics {
@@ -70,7 +76,8 @@ mod tests {
                 response_bytes,
             });
 
-            request = crate::pull::request(root, Some(response), config, client_store).await?;
+            request = crate::pull::request(root, Some(response), config, client_store, &NoCache())
+                .await?;
             if request.indicates_finished() {
                 break;
             }
@@ -88,11 +95,11 @@ mod tests {
 
         // client should have all data
         let client_cids = DagWalk::breadth_first([root])
-            .stream(client_store)
+            .stream(client_store, &NoCache())
             .try_collect::<HashSet<_>>()
             .await?;
         let server_cids = DagWalk::breadth_first([root])
-            .stream(server_store)
+            .stream(server_store, &NoCache())
             .try_collect::<HashSet<_>>()
             .await?;
 
@@ -108,6 +115,7 @@ mod proptests {
         common::Config,
         dag_walk::DagWalk,
         test_utils::{setup_blockstore, variable_blocksize_dag},
+        traits::NoCache,
     };
     use futures::TryStreamExt;
     use libipld::{Cid, Ipld};
@@ -133,12 +141,12 @@ mod proptests {
 
             // client should have all data
             let client_cids = DagWalk::breadth_first([root])
-                .stream(client_store)
+                .stream(client_store, &NoCache())
                 .try_collect::<HashSet<_>>()
                 .await
                 .unwrap();
             let server_cids = DagWalk::breadth_first([root])
-                .stream(server_store)
+                .stream(server_store, &NoCache())
                 .try_collect::<HashSet<_>>()
                 .await
                 .unwrap();

--- a/car-mirror/src/push.rs
+++ b/car-mirror/src/push.rs
@@ -98,12 +98,10 @@ mod tests {
         // receiver should have all data
         let client_cids = DagWalk::breadth_first([root])
             .stream(client_store)
-            .map_ok(|(cid, _)| cid)
             .try_collect::<HashSet<_>>()
             .await?;
         let server_cids = DagWalk::breadth_first([root])
             .stream(server_store)
-            .map_ok(|(cid, _)| cid)
             .try_collect::<HashSet<_>>()
             .await?;
 
@@ -210,13 +208,11 @@ mod proptests {
             // client should have all data
             let client_cids = DagWalk::breadth_first([root])
                 .stream(client_store)
-                .map_ok(|(cid, _)| cid)
                 .try_collect::<HashSet<_>>()
                 .await
                 .unwrap();
             let server_cids = DagWalk::breadth_first([root])
                 .stream(server_store)
-                .map_ok(|(cid, _)| cid)
                 .try_collect::<HashSet<_>>()
                 .await
                 .unwrap();

--- a/car-mirror/src/push.rs
+++ b/car-mirror/src/push.rs
@@ -73,12 +73,11 @@ mod tests {
         server_store: &MemoryBlockStore,
     ) -> Result<Vec<Metrics>> {
         let mut metrics = Vec::new();
-        let mut request =
-            crate::push::request(root, None, config, client_store, &NoCache()).await?;
+        let mut request = crate::push::request(root, None, config, client_store, &NoCache).await?;
         loop {
             let request_bytes = request.bytes.len();
             let response =
-                crate::push::response(root, request, config, server_store, &NoCache()).await?;
+                crate::push::response(root, request, config, server_store, &NoCache).await?;
             let response_bytes = serde_ipld_dagcbor::to_vec(&response)?.len();
 
             metrics.push(Metrics {
@@ -89,8 +88,8 @@ mod tests {
             if response.indicates_finished() {
                 break;
             }
-            request = crate::push::request(root, Some(response), config, client_store, &NoCache())
-                .await?;
+            request =
+                crate::push::request(root, Some(response), config, client_store, &NoCache).await?;
         }
 
         Ok(metrics)
@@ -104,11 +103,11 @@ mod tests {
 
         // receiver should have all data
         let client_cids = DagWalk::breadth_first([root])
-            .stream(client_store, &NoCache())
+            .stream(client_store, &NoCache)
             .try_collect::<HashSet<_>>()
             .await?;
         let server_cids = DagWalk::breadth_first([root])
-            .stream(server_store, &NoCache())
+            .stream(server_store, &NoCache)
             .try_collect::<HashSet<_>>()
             .await?;
 
@@ -215,12 +214,12 @@ mod proptests {
 
             // client should have all data
             let client_cids = DagWalk::breadth_first([root])
-                .stream(client_store, &NoCache())
+                .stream(client_store, &NoCache)
                 .try_collect::<HashSet<_>>()
                 .await
                 .unwrap();
             let server_cids = DagWalk::breadth_first([root])
-                .stream(server_store, &NoCache())
+                .stream(server_store, &NoCache)
                 .try_collect::<HashSet<_>>()
                 .await
                 .unwrap();

--- a/car-mirror/src/test_utils/local_utils.rs
+++ b/car-mirror/src/test_utils/local_utils.rs
@@ -1,6 +1,6 @@
 ///! Crate-local test utilities
 use super::{arb_ipld_dag, links_to_padded_ipld, setup_blockstore, Rvg};
-use crate::{common::references, dag_walk::DagWalk, error::Error};
+use crate::{common::references, dag_walk::DagWalk, error::Error, traits::NoCache};
 use anyhow::Result;
 use futures::TryStreamExt;
 use libipld::{Cid, Ipld};
@@ -70,7 +70,7 @@ pub(crate) async fn setup_random_dag(
 
 pub(crate) async fn total_dag_bytes(root: Cid, store: &impl BlockStore) -> Result<usize> {
     Ok(DagWalk::breadth_first([root])
-        .stream(store)
+        .stream(store, &NoCache())
         .try_filter_map(|cid| async move {
             let block = store
                 .get_block(&cid)
@@ -86,7 +86,7 @@ pub(crate) async fn total_dag_bytes(root: Cid, store: &impl BlockStore) -> Resul
 
 pub(crate) async fn total_dag_blocks(root: Cid, store: &impl BlockStore) -> Result<usize> {
     Ok(DagWalk::breadth_first([root])
-        .stream(store)
+        .stream(store, &NoCache())
         .try_collect::<Vec<_>>()
         .await?
         .len())

--- a/car-mirror/src/test_utils/local_utils.rs
+++ b/car-mirror/src/test_utils/local_utils.rs
@@ -70,7 +70,7 @@ pub(crate) async fn setup_random_dag(
 
 pub(crate) async fn total_dag_bytes(root: Cid, store: &impl BlockStore) -> Result<usize> {
     Ok(DagWalk::breadth_first([root])
-        .stream(store, &NoCache())
+        .stream(store, &NoCache)
         .try_filter_map(|cid| async move {
             let block = store
                 .get_block(&cid)
@@ -86,7 +86,7 @@ pub(crate) async fn total_dag_bytes(root: Cid, store: &impl BlockStore) -> Resul
 
 pub(crate) async fn total_dag_blocks(root: Cid, store: &impl BlockStore) -> Result<usize> {
     Ok(DagWalk::breadth_first([root])
-        .stream(store, &NoCache())
+        .stream(store, &NoCache)
         .try_collect::<Vec<_>>()
         .await?
         .len())

--- a/car-mirror/src/test_utils/local_utils.rs
+++ b/car-mirror/src/test_utils/local_utils.rs
@@ -1,6 +1,6 @@
 ///! Crate-local test utilities
 use super::{arb_ipld_dag, links_to_padded_ipld, setup_blockstore, Rvg};
-use crate::{common::references, dag_walk::DagWalk};
+use crate::{common::references, dag_walk::DagWalk, error::Error};
 use anyhow::Result;
 use futures::TryStreamExt;
 use libipld::{Cid, Ipld};
@@ -71,7 +71,13 @@ pub(crate) async fn setup_random_dag(
 pub(crate) async fn total_dag_bytes(root: Cid, store: &impl BlockStore) -> Result<usize> {
     Ok(DagWalk::breadth_first([root])
         .stream(store)
-        .map_ok(|(_, block)| block.len())
+        .try_filter_map(|cid| async move {
+            let block = store
+                .get_block(&cid)
+                .await
+                .map_err(Error::BlockStoreError)?;
+            Ok(Some(block.len()))
+        })
         .try_collect::<Vec<_>>()
         .await?
         .into_iter()
@@ -81,7 +87,6 @@ pub(crate) async fn total_dag_bytes(root: Cid, store: &impl BlockStore) -> Resul
 pub(crate) async fn total_dag_blocks(root: Cid, store: &impl BlockStore) -> Result<usize> {
     Ok(DagWalk::breadth_first([root])
         .stream(store)
-        .map_ok(|(_, block)| block.len())
         .try_collect::<Vec<_>>()
         .await?
         .len())

--- a/car-mirror/src/traits.rs
+++ b/car-mirror/src/traits.rs
@@ -99,7 +99,7 @@ impl Cache for InMemoryCache {
 
 /// An implementation of `Cache` that doesn't cache at all.
 #[derive(Debug)]
-pub struct NoCache();
+pub struct NoCache;
 
 #[async_trait(?Send)]
 impl Cache for NoCache {

--- a/car-mirror/src/traits.rs
+++ b/car-mirror/src/traits.rs
@@ -11,8 +11,8 @@ use wnfs_common::BlockStore;
 /// At the moment, all caches are conceptually memoization tables, so you don't
 /// necessarily need to think about being careful about cache eviction.
 ///
-/// See `InMemoryCache` for a `quick_cache`-based implementation, and
-/// `NoCache` for disabling the cache.
+/// See `InMemoryCache` for a `quick_cache`-based implementation
+/// (enable the `quick-cache` feature), and `NoCache` for disabling the cache.
 #[async_trait(?Send)]
 pub trait Cache {
     /// This returns further references from the block referenced by given CID,
@@ -51,11 +51,13 @@ pub trait Cache {
 /// A [quick-cache]-based implementation of a car mirror cache.
 ///
 /// [quick-cache]: https://github.com/arthurprs/quick-cache/
+#[cfg(feature = "quick_cache")]
 #[derive(Debug)]
 pub struct InMemoryCache {
     references: quick_cache::sync::Cache<Cid, Vec<Cid>>,
 }
 
+#[cfg(feature = "quick_cache")]
 impl InMemoryCache {
     /// Create a new in-memory cache that approximately holds
     /// cached references for `approx_capacity` CIDs.
@@ -82,6 +84,7 @@ impl InMemoryCache {
     }
 }
 
+#[cfg(feature = "quick_cache")]
 #[async_trait(?Send)]
 impl Cache for InMemoryCache {
     async fn get_references_cached(&self, cid: Cid) -> Result<Option<Vec<Cid>>> {

--- a/car-mirror/src/traits.rs
+++ b/car-mirror/src/traits.rs
@@ -1,0 +1,68 @@
+use crate::common::references;
+use anyhow::Result;
+use async_trait::async_trait;
+use libipld::{Cid, IpldCodec};
+use wnfs_common::BlockStore;
+
+#[async_trait(?Send)]
+pub trait Cache {
+    async fn get_references_cached(&self, cid: Cid) -> Result<Option<Vec<Cid>>>;
+
+    async fn put_references_cached(&self, cid: Cid, references: Vec<Cid>) -> Result<()>;
+
+    async fn references(&self, cid: Cid, store: &impl BlockStore) -> Result<Vec<Cid>> {
+        // raw blocks don't have further links
+        let raw_codec: u64 = IpldCodec::Raw.into();
+        if cid.codec() == raw_codec {
+            return Ok(Vec::new());
+        }
+
+        if let Some(refs) = self.get_references_cached(cid).await? {
+            return Ok(refs);
+        }
+
+        let block = store.get_block(&cid).await?;
+        let refs = references(cid, block, Vec::new())?;
+        self.put_references_cached(cid, refs.clone()).await?;
+        Ok(refs)
+    }
+}
+
+#[derive(Debug)]
+pub struct InMemoryCache {
+    references: quick_cache::sync::Cache<Cid, Vec<Cid>>,
+}
+
+impl InMemoryCache {
+    pub fn new(approx_capacity: usize) -> Self {
+        Self {
+            references: quick_cache::sync::Cache::new(approx_capacity),
+        }
+    }
+}
+
+#[async_trait(?Send)]
+impl Cache for InMemoryCache {
+    async fn get_references_cached(&self, cid: Cid) -> Result<Option<Vec<Cid>>> {
+        Ok(self.references.get(&cid))
+    }
+
+    async fn put_references_cached(&self, cid: Cid, references: Vec<Cid>) -> Result<()> {
+        self.references.insert(cid, references);
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+pub struct NoCache();
+
+#[async_trait(?Send)]
+impl Cache for NoCache {
+    async fn get_references_cached(&self, cid: Cid) -> Result<Option<Vec<Cid>>> {
+        Ok(None)
+    }
+
+    async fn put_references_cached(&self, cid: Cid, references: Vec<Cid>) -> Result<()> {
+        Ok(())
+    }
+}


### PR DESCRIPTION
This is a performance optimization for CAR mirror.

This helps, especially when DAGs are huge, blockstores are locally slow (e.g. reading from disk) and when latency is not the main issue anymore.

It improves benchmarks quite a bit:
![image](https://github.com/fission-codes/rs-car-mirror/assets/1430958/d3507943-ad60-409a-9af0-966f2ca37f46)

---

What this PR is doing is simply implementing one version of #28: A cache for block references: `Cid -> Vec<Cid>`.
This way, when there's a cache hit, we don't even need to fetch the block, parse it and find links. Instead, we get further references directly.

In some cases, this means running the same operation twice won't fetch any block from the blockstore at all.

Since different environments will want to implement different types of caches (e.g. the `quick-cache` based cache won't work in Wasm), the cache implementation is abstracted behind a `trait Cache`.

I've bundled two implementations: `NoCache` that simply always re-computed the value (no memoization), and `InMemoryCache` which uses the `quick_cache` library.

---

This PR depends on #29 