### PR TITLE
fix: Correctly handle raw-codec CIDs/blocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -404,6 +404,7 @@ dependencies = [
  "serde",
  "serde_ipld_dagcbor",
  "test-strategy",
+ "testresult",
  "thiserror",
  "tokio",
  "tracing",
@@ -1868,6 +1869,12 @@ dependencies = [
  "structmeta",
  "syn 2.0.28",
 ]
+
+[[package]]
+name = "testresult"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52e045f5cf9ad69772c1c9652f5567a75df88bbb5a1310a64e53cab140c5c459"
 
 [[package]]
 name = "textwrap"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -655,6 +655,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.0",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1691,9 +1704,9 @@ dependencies = [
 
 [[package]]
 name = "serde_ipld_dagcbor"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace39c1b7526be78c755a4c698313f699cf44e62408c0029bf9ab9450fe836da"
+checksum = "8e880e0b1f9c7a8db874642c1217f7e19b29e325f24ab9f0fcb11818adec7f01"
 dependencies = [
  "cbor4ii",
  "cid",
@@ -2276,21 +2289,24 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "wnfs-common"
-version = "0.1.24"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7dd203b73bbbbbf175a8a733ef6aa843f020095f5f4d1e6cd3b7fdce8ba4d8"
+checksum = "1395a47e38402df060d3448fe153c5af1eae6f27aeca9c2e79e5a39bb355efab"
 dependencies = [
  "anyhow",
  "async-once-cell",
  "async-trait",
  "bytes",
  "chrono",
+ "dashmap",
  "futures",
  "libipld",
  "multihash",
  "once_cell",
+ "parking_lot",
  "rand_core",
  "serde",
+ "serde_ipld_dagcbor",
  "thiserror",
 ]
 

--- a/car-mirror-benches/benches/artificially_slow_blockstore.rs
+++ b/car-mirror-benches/benches/artificially_slow_blockstore.rs
@@ -28,9 +28,9 @@ pub fn push_throttled(c: &mut Criterion) {
             },
             |(client_store, root)| {
                 let client_store = &ThrottledBlockStore(client_store);
-                let client_cache = &InMemoryCache::new(10_000);
+                let client_cache = &InMemoryCache::new(10_000, 150_000);
                 let server_store = &ThrottledBlockStore::new();
-                let server_cache = &InMemoryCache::new(10_000);
+                let server_cache = &InMemoryCache::new(10_000, 150_000);
                 let config = &Config::default();
 
                 // Simulate a multi-round protocol run in-memory
@@ -75,9 +75,9 @@ pub fn pull_throttled(c: &mut Criterion) {
             },
             |(server_store, root)| {
                 let server_store = &ThrottledBlockStore(server_store);
-                let server_cache = &InMemoryCache::new(10_000);
+                let server_cache = &InMemoryCache::new(10_000, 150_000);
                 let client_store = &ThrottledBlockStore::new();
-                let client_cache = &InMemoryCache::new(10_000);
+                let client_cache = &InMemoryCache::new(10_000, 150_000);
                 let config = &Config::default();
 
                 // Simulate a multi-round protocol run in-memory

--- a/car-mirror-benches/benches/in_memory.rs
+++ b/car-mirror-benches/benches/in_memory.rs
@@ -22,9 +22,9 @@ pub fn push(c: &mut Criterion) {
                 (store, root)
             },
             |(ref client_store, root)| {
-                let client_cache = &InMemoryCache::new(10_000);
+                let client_cache = &InMemoryCache::new(10_000, 150_000);
                 let server_store = &MemoryBlockStore::new();
-                let server_cache = &InMemoryCache::new(10_000);
+                let server_cache = &InMemoryCache::new(10_000, 150_000);
                 let config = &Config::default();
 
                 // Simulate a multi-round protocol run in-memory
@@ -68,9 +68,9 @@ pub fn pull(c: &mut Criterion) {
                 (store, root)
             },
             |(ref server_store, root)| {
-                let server_cache = &InMemoryCache::new(10_000);
+                let server_cache = &InMemoryCache::new(10_000, 150_000);
                 let client_store = &MemoryBlockStore::new();
-                let client_cache = &InMemoryCache::new(10_000);
+                let client_cache = &InMemoryCache::new(10_000, 150_000);
                 let config = &Config::default();
 
                 // Simulate a multi-round protocol run in-memory

--- a/car-mirror-benches/benches/simulated_latency.rs
+++ b/car-mirror-benches/benches/simulated_latency.rs
@@ -68,12 +68,12 @@ pub fn pull_with_simulated_latency(
                     links_to_padded_ipld(block_padding),
                 ));
                 let store = async_std::task::block_on(setup_blockstore(blocks)).unwrap();
-                let cache = InMemoryCache::new(10_000);
+                let cache = InMemoryCache::new(10_000, 150_000);
                 (store, cache, root)
             },
             |(ref server_store, ref server_cache, root)| {
                 let client_store = &MemoryBlockStore::new();
-                let client_cache = &InMemoryCache::new(10_000);
+                let client_cache = &InMemoryCache::new(10_000, 150_000);
                 let config = &Config::default();
 
                 // Simulate a multi-round protocol run in-memory
@@ -145,12 +145,12 @@ pub fn push_with_simulated_latency(
                     links_to_padded_ipld(block_padding),
                 ));
                 let store = async_std::task::block_on(setup_blockstore(blocks)).unwrap();
-                let cache = InMemoryCache::new(10_000);
+                let cache = InMemoryCache::new(10_000, 150_000);
                 (store, cache, root)
             },
             |(ref client_store, ref client_cache, root)| {
                 let server_store = &MemoryBlockStore::new();
-                let server_cache = &InMemoryCache::new(10_000);
+                let server_cache = &InMemoryCache::new(10_000, 150_000);
                 let config = &Config::default();
 
                 // Simulate a multi-round protocol run in-memory

--- a/car-mirror-wasm/src/lib.rs
+++ b/car-mirror-wasm/src/lib.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(missing_debug_implementations, missing_docs, rust_2018_idioms)]
-#![deny(unreachable_pub, private_in_public)]
+#![deny(unreachable_pub)]
 
 //! car-mirror
 

--- a/car-mirror/Cargo.toml
+++ b/car-mirror/Cargo.toml
@@ -49,6 +49,7 @@ car-mirror = { path = ".", features = ["test_utils"] }
 proptest = "1.1"
 roaring-graphs = "0.12"
 test-strategy = "0.3"
+testresult = "0.3.0"
 
 [features]
 default = []

--- a/car-mirror/Cargo.toml
+++ b/car-mirror/Cargo.toml
@@ -41,7 +41,7 @@ thiserror = "1.0"
 tokio = { version = "^1", default-features = false }
 tracing = "0.1"
 tracing-subscriber = "0.3"
-wnfs-common = "0.1.24"
+wnfs-common = "0.1.26"
 
 [dev-dependencies]
 async-std = { version = "1.11", features = ["attributes"] }

--- a/car-mirror/src/common.rs
+++ b/car-mirror/src/common.rs
@@ -472,17 +472,20 @@ impl Default for Config {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::test_utils::assert_cond_send_sync;
+    use wnfs_common::MemoryBlockStore;
 
-    fn send_sync_tests() {
+    use super::*;
+    use crate::{test_utils::assert_cond_send_sync, traits::NoCache};
+
+    #[allow(clippy::unreachable, unused)]
+    fn test_assert_send() {
         assert_cond_send_sync(|| {
             block_send(
                 unimplemented!(),
                 unimplemented!(),
                 unimplemented!(),
-                unimplemented!(),
-                unimplemented!(),
+                unimplemented!() as &MemoryBlockStore,
+                &NoCache,
             )
         });
         assert_cond_send_sync(|| {
@@ -490,8 +493,8 @@ mod tests {
                 unimplemented!(),
                 unimplemented!(),
                 unimplemented!(),
-                unimplemented!(),
-                unimplemented!(),
+                unimplemented!() as &MemoryBlockStore,
+                &NoCache,
             )
         })
     }

--- a/car-mirror/src/common.rs
+++ b/car-mirror/src/common.rs
@@ -61,7 +61,10 @@ impl std::fmt::Debug for ReceiverState {
                 )
             });
         f.debug_struct("ReceiverState")
-            .field("missing_subgraph_roots", &self.missing_subgraph_roots)
+            .field(
+                "missing_subgraph_roots.len() == ",
+                &self.missing_subgraph_roots.len(),
+            )
             .field("have_cids_bloom", &have_cids_bloom)
             .finish()
     }
@@ -86,7 +89,7 @@ pub struct CarFile {
 ///
 /// It returns a `CarFile` of (a subset) of all blocks below `root`, that
 /// are thought to be missing on the receiving end.
-#[instrument(skip(config, store, cache))]
+#[instrument(skip_all, fields(root, last_state))]
 pub async fn block_send(
     root: Cid,
     last_state: Option<ReceiverState>,
@@ -145,7 +148,7 @@ pub async fn block_send(
 /// It takes a `CarFile`, verifies that its contents are related to the
 /// `root` and returns some information to help the block sending side
 /// figure out what blocks to send next.
-#[instrument(skip(last_car, config, store, cache), fields(car_bytes = last_car.as_ref().map(|car| car.bytes.len())))]
+#[instrument(skip_all, fields(root, car_bytes = last_car.as_ref().map(|car| car.bytes.len())))]
 pub async fn block_receive(
     root: Cid,
     last_car: Option<CarFile>,

--- a/car-mirror/src/common.rs
+++ b/car-mirror/src/common.rs
@@ -450,3 +450,31 @@ impl Default for Config {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::assert_send_sync;
+
+    #[cfg(not(target_arch = "wasm32"))]
+    fn send_sync_tests() {
+        assert_send_sync(|| {
+            block_send(
+                unimplemented!(),
+                unimplemented!(),
+                unimplemented!(),
+                unimplemented!(),
+                unimplemented!(),
+            )
+        });
+        assert_send_sync(|| {
+            block_receive(
+                unimplemented!(),
+                unimplemented!(),
+                unimplemented!(),
+                unimplemented!(),
+                unimplemented!(),
+            )
+        })
+    }
+}

--- a/car-mirror/src/common.rs
+++ b/car-mirror/src/common.rs
@@ -472,10 +472,9 @@ impl Default for Config {
 
 #[cfg(test)]
 mod tests {
-    use wnfs_common::MemoryBlockStore;
-
     use super::*;
     use crate::{test_utils::assert_cond_send_sync, traits::NoCache};
+    use wnfs_common::MemoryBlockStore;
 
     #[allow(clippy::unreachable, unused)]
     fn test_assert_send() {

--- a/car-mirror/src/common.rs
+++ b/car-mirror/src/common.rs
@@ -221,7 +221,7 @@ pub fn references<E: Extend<Cid>>(
 
 async fn verify_missing_subgraph_roots(
     root: Cid,
-    missing_subgraph_roots: &Vec<Cid>,
+    missing_subgraph_roots: &[Cid],
     store: &impl BlockStore,
     cache: &impl Cache,
 ) -> Result<Vec<Cid>, Error> {

--- a/car-mirror/src/common.rs
+++ b/car-mirror/src/common.rs
@@ -470,7 +470,6 @@ impl Default for Config {
     }
 }
 
-#[cfg(fuckoff)]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/car-mirror/src/lib.rs
+++ b/car-mirror/src/lib.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![warn(missing_debug_implementations, missing_docs, rust_2018_idioms)]
-#![deny(unreachable_pub, private_in_public)]
+#![deny(unreachable_pub)]
 
 //! car-mirror
 

--- a/car-mirror/src/pull.rs
+++ b/car-mirror/src/pull.rs
@@ -54,13 +54,13 @@ mod tests {
     use futures::TryStreamExt;
     use libipld::Cid;
     use std::collections::HashSet;
-    use wnfs_common::MemoryBlockStore;
+    use wnfs_common::{BlockStore, MemoryBlockStore};
 
     pub(crate) async fn simulate_protocol(
         root: Cid,
         config: &Config,
-        client_store: &MemoryBlockStore,
-        server_store: &MemoryBlockStore,
+        client_store: &impl BlockStore,
+        server_store: &impl BlockStore,
     ) -> Result<Vec<Metrics>> {
         let mut metrics = Vec::new();
         let mut request = crate::pull::request(root, None, config, client_store, &NoCache).await?;

--- a/car-mirror/src/push.rs
+++ b/car-mirror/src/push.rs
@@ -64,13 +64,13 @@ mod tests {
     use libipld::Cid;
     use proptest::collection::vec;
     use std::collections::HashSet;
-    use wnfs_common::MemoryBlockStore;
+    use wnfs_common::{BlockStore, MemoryBlockStore};
 
     pub(crate) async fn simulate_protocol(
         root: Cid,
         config: &Config,
-        client_store: &MemoryBlockStore,
-        server_store: &MemoryBlockStore,
+        client_store: &impl BlockStore,
+        server_store: &impl BlockStore,
     ) -> Result<Vec<Metrics>> {
         let mut metrics = Vec::new();
         let mut request = crate::push::request(root, None, config, client_store, &NoCache).await?;

--- a/car-mirror/src/test_utils/blockstore_utils.rs
+++ b/car-mirror/src/test_utils/blockstore_utils.rs
@@ -20,8 +20,9 @@ pub async fn setup_existing_blockstore(
     store: &impl BlockStore,
 ) -> Result<()> {
     for (cid, ipld) in blocks.into_iter() {
-        let block: Bytes = encode(&ipld, IpldCodec::DagCbor)?.into();
-        let cid_store = store.put_block(block, IpldCodec::DagCbor.into()).await?;
+        let codec: IpldCodec = cid.codec().try_into()?;
+        let block: Bytes = encode(&ipld, codec)?.into();
+        let cid_store = store.put_block(block, codec.into()).await?;
         debug_assert_eq!(cid, cid_store);
     }
 
@@ -36,7 +37,8 @@ pub fn dag_to_dot(
     writeln!(writer, "digraph {{")?;
 
     for (cid, ipld) in blocks {
-        let bytes = encode(&ipld, IpldCodec::DagCbor)?;
+        let codec: IpldCodec = cid.codec().try_into()?;
+        let bytes = encode(&ipld, codec)?;
         let refs = references(cid, bytes, Vec::new())?;
         for to_cid in refs {
             print_truncated_string(writer, cid.to_string())?;

--- a/car-mirror/src/test_utils/local_utils.rs
+++ b/car-mirror/src/test_utils/local_utils.rs
@@ -5,7 +5,7 @@ use anyhow::Result;
 use futures::TryStreamExt;
 use libipld::{Cid, Ipld};
 use proptest::strategy::Strategy;
-use wnfs_common::{BlockStore, MemoryBlockStore};
+use wnfs_common::{utils::CondSync, BlockStore, MemoryBlockStore};
 
 #[derive(Clone, Debug)]
 pub(crate) struct Metrics {
@@ -92,4 +92,4 @@ pub(crate) async fn total_dag_blocks(root: Cid, store: &impl BlockStore) -> Resu
         .len())
 }
 
-pub(crate) fn assert_send_sync<T: Send + Sync>(fut: fn() -> T) {}
+pub(crate) fn assert_cond_send_sync<T: CondSync>(fut: fn() -> T) {}

--- a/car-mirror/src/test_utils/local_utils.rs
+++ b/car-mirror/src/test_utils/local_utils.rs
@@ -5,7 +5,7 @@ use anyhow::Result;
 use futures::TryStreamExt;
 use libipld::{Cid, Ipld};
 use proptest::strategy::Strategy;
-use wnfs_common::{utils::CondSync, BlockStore, MemoryBlockStore};
+use wnfs_common::{utils::CondSend, BlockStore, MemoryBlockStore};
 
 #[derive(Clone, Debug)]
 pub(crate) struct Metrics {
@@ -92,4 +92,4 @@ pub(crate) async fn total_dag_blocks(root: Cid, store: &impl BlockStore) -> Resu
         .len())
 }
 
-pub(crate) fn assert_cond_send_sync<T: CondSync>(fut: fn() -> T) {}
+pub(crate) fn assert_cond_send_sync<T: CondSend>(_fut: fn() -> T) {}

--- a/car-mirror/src/test_utils/local_utils.rs
+++ b/car-mirror/src/test_utils/local_utils.rs
@@ -91,3 +91,5 @@ pub(crate) async fn total_dag_blocks(root: Cid, store: &impl BlockStore) -> Resu
         .await?
         .len())
 }
+
+pub(crate) fn assert_send_sync<T: Send + Sync>(fut: fn() -> T) {}

--- a/car-mirror/src/traits.rs
+++ b/car-mirror/src/traits.rs
@@ -2,10 +2,9 @@ use crate::common::references;
 use anyhow::Result;
 use async_trait::async_trait;
 use libipld::{Cid, IpldCodec};
-use wnfs_common::{
-    utils::{Arc, CondSync},
-    BlockStore, BlockStoreError,
-};
+#[cfg(feature = "quick_cache")]
+use wnfs_common::utils::Arc;
+use wnfs_common::{utils::CondSync, BlockStore, BlockStoreError};
 
 /// This trait abstracts caches used by the car mirror implementation.
 /// An efficient cache implementation can significantly reduce the amount

--- a/car-mirror/src/traits.rs
+++ b/car-mirror/src/traits.rs
@@ -183,7 +183,8 @@ impl Cache for NoCache {
     }
 }
 
-#[cfg(all(test, feature = "quick_cache"))]
+#[cfg(feature = "quick_cache")]
+#[cfg(test)]
 mod quick_cache_tests {
     use super::{Cache, InMemoryCache};
     use libipld::{Ipld, IpldCodec};


### PR DESCRIPTION
Major things in this PR:
- Correctly handle raw-codec CIDs/blocks, they were previously not transferred due to a bug in `IncrementalDagVerification`.
- Update wnfs-common to 0.1.26 so this crate is compatible with the latest rs-wnfs.
- Introduce another cache, a positive cache for checking if we already have a block. (Work on #28)
- Make sure the main request/response futures are `Send`