### PR TITLE
feat: Implement half-duplex streaming

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,28 +181,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-stream"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
-dependencies = [
- "async-stream-impl",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-stream-impl"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.28",
-]
-
-[[package]]
 name = "async-task"
 version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -389,7 +367,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-std",
- "async-stream",
  "async-trait",
  "bytes",
  "car-mirror",
@@ -403,6 +380,7 @@ dependencies = [
  "roaring-graphs",
  "serde",
  "serde_ipld_dagcbor",
+ "test-log",
  "test-strategy",
  "testresult",
  "thiserror",
@@ -1206,6 +1184,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1566,6 +1553,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1749,9 +1745,9 @@ dependencies = [
 
 [[package]]
 name = "sharded-slab"
-version = "0.1.4"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
@@ -1856,6 +1852,27 @@ dependencies = [
  "redox_syscall",
  "rustix",
  "windows-sys",
+]
+
+[[package]]
+name = "test-log"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6159ab4116165c99fc88cce31f99fa2c9dbe08d3691cb38da02fc3b45f357d2b"
+dependencies = [
+ "test-log-macros",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "test-log-macros"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ba277e77219e9eea169e8508942db1bf5d8a41ff2db9b20aab5a5aadc9fa25d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -1978,27 +1995,45 @@ dependencies = [
 
 [[package]]
 name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
 dependencies = [
- "lazy_static",
- "log",
+ "serde",
  "tracing-core",
 ]
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "parking_lot",
+ "regex",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/car-mirror/Cargo.toml
+++ b/car-mirror/Cargo.toml
@@ -24,7 +24,6 @@ doc = true
 
 [dependencies]
 anyhow = "1.0"
-async-stream = "0.3.5"
 async-trait = "0.1.73"
 bytes = "1.4"
 deterministic-bloom = "0.1"
@@ -40,7 +39,6 @@ serde_ipld_dagcbor = "0.4"
 thiserror = "1.0"
 tokio = { version = "^1", default-features = false }
 tracing = "0.1"
-tracing-subscriber = "0.3"
 wnfs-common = "0.1.26"
 
 [dev-dependencies]

--- a/car-mirror/Cargo.toml
+++ b/car-mirror/Cargo.toml
@@ -46,8 +46,10 @@ async-std = { version = "1.11", features = ["attributes"] }
 car-mirror = { path = ".", features = ["test_utils"] }
 proptest = "1.1"
 roaring-graphs = "0.12"
+test-log = { version = "0.2", default-features = false, features = ["trace"] }
 test-strategy = "0.3"
-testresult = "0.3.0"
+testresult = "0.3"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "json", "parking_lot", "registry"] }
 
 [features]
 default = []

--- a/car-mirror/src/common.rs
+++ b/car-mirror/src/common.rs
@@ -92,7 +92,9 @@ pub async fn block_send(
     })
 }
 
-/// TODO(matheus23): Docs
+/// This is the streaming equivalent of `block_send`.
+///
+/// It uses the car file format for framing blocks & CIDs in the given `AsyncWrite`.
 #[instrument(skip_all, fields(root, last_state))]
 pub async fn block_send_car_stream<'a, W: tokio::io::AsyncWrite + Unpin + Send>(
     root: Cid,
@@ -106,7 +108,8 @@ pub async fn block_send_car_stream<'a, W: tokio::io::AsyncWrite + Unpin + Send>(
     write_blocks_into_car(stream, &mut block_stream, send_limit).await
 }
 
-/// TODO(matheus23): Docs
+/// This is the car mirror block sending function, but unlike `block_send_car_stream`
+/// it leaves framing blocks to the caller.
 pub async fn block_send_block_stream<'a>(
     root: Cid,
     last_state: Option<ReceiverState>,
@@ -171,7 +174,7 @@ pub async fn block_receive(
     Ok(receiver_state)
 }
 
-/// TODO(matheus23): Docs
+/// Like `block_receive`, but allows consuming the CAR file as a stream.
 #[instrument(skip_all, fields(root))]
 pub async fn block_receive_car_stream<R: tokio::io::AsyncRead + Unpin + CondSend>(
     root: Cid,

--- a/car-mirror/src/common.rs
+++ b/car-mirror/src/common.rs
@@ -2,13 +2,16 @@
 
 use bytes::Bytes;
 use deterministic_bloom::runtime_size::BloomFilter;
-use futures::TryStreamExt;
+use futures::{future, TryStreamExt};
 use iroh_car::{CarHeader, CarReader, CarWriter};
 use libipld::{Ipld, IpldCodec};
 use libipld_core::{cid::Cid, codec::References};
 use std::io::Cursor;
 use tracing::{debug, instrument, trace, warn};
-use wnfs_common::BlockStore;
+use wnfs_common::{
+    utils::{BoxStream, CondSend},
+    BlockStore,
+};
 
 use crate::{
     dag_walk::DagWalk,
@@ -25,16 +28,12 @@ use crate::{
 /// Configuration values (such as byte limits) for the CAR mirror protocol
 #[derive(Clone, Debug)]
 pub struct Config {
-    /// A client will try to send at least `send_minimum` bytes of block data
-    /// in each request, except if close to the end of the protocol (when there's)
-    /// not that much data left.
-    pub send_minimum: usize,
-    /// The maximum number of bytes per request that the server accepts.
+    /// The maximum number of bytes per request that a recipient should.
     pub receive_maximum: usize,
-    /// The maximum number of roots per request that the server will send to the client,
-    /// and that the client will consume.
+    /// The maximum number of roots per request that will be requested by the recipient
+    /// to be sent by the sender.
     pub max_roots_per_round: usize,
-    /// The target false positive rate for the bloom filter that the server sends.
+    /// The target false positive rate for the bloom filter that the recipient sends.
     pub bloom_fpr: fn(u64) -> f64,
 }
 
@@ -56,6 +55,9 @@ pub struct CarFile {
     pub bytes: Bytes,
 }
 
+/// TODO(matheus23): Docs
+pub type BlockStream<'a> = BoxStream<'a, Result<(Cid, Bytes), Error>>;
+
 //--------------------------------------------------------------------------------------------------
 // Functions
 //--------------------------------------------------------------------------------------------------
@@ -75,8 +77,38 @@ pub async fn block_send(
     store: &impl BlockStore,
     cache: &impl Cache,
 ) -> Result<CarFile, Error> {
+    let mut block_stream = block_send_block_stream(root, last_state, store, cache).await?;
+
+    let bytes =
+        write_blocks_into_car(Vec::new(), &mut block_stream, Some(config.receive_maximum)).await?;
+
+    Ok(CarFile {
+        bytes: bytes.into(),
+    })
+}
+
+/// TODO(matheus23): Docs
+#[instrument(skip_all, fields(root, last_state))]
+pub async fn block_send_car_stream<'a, W: tokio::io::AsyncWrite + Unpin + Send>(
+    root: Cid,
+    last_state: Option<ReceiverState>,
+    stream: W,
+    store: &impl BlockStore,
+    cache: &impl Cache,
+) -> Result<W, Error> {
+    let mut block_stream = block_send_block_stream(root, last_state, store, cache).await?;
+    write_blocks_into_car(stream, &mut block_stream, None).await
+}
+
+/// TODO(matheus23): Docs
+pub async fn block_send_block_stream<'a>(
+    root: Cid,
+    last_state: Option<ReceiverState>,
+    store: &'a impl BlockStore,
+    cache: &'a impl Cache,
+) -> Result<BlockStream<'a>, Error> {
     let ReceiverState {
-        ref missing_subgraph_roots,
+        missing_subgraph_roots,
         have_cids_bloom,
     } = last_state.unwrap_or(ReceiverState {
         missing_subgraph_roots: vec![root],
@@ -85,37 +117,13 @@ pub async fn block_send(
 
     // Verify that all missing subgraph roots are in the relevant DAG:
     let subgraph_roots =
-        verify_missing_subgraph_roots(root, missing_subgraph_roots, store, cache).await?;
+        verify_missing_subgraph_roots(root, &missing_subgraph_roots, store, cache).await?;
 
     let bloom = handle_missing_bloom(have_cids_bloom);
 
-    let mut writer = CarWriter::new(
-        CarHeader::new_v1(
-            // https://github.com/wnfs-wg/car-mirror-spec/issues/6
-            // CAR files *must* have at least one CID in them, and all of them
-            // need to appear as a block in the payload.
-            // It would probably make most sense to just write all subgraph roots into this,
-            // but we don't know how many of the subgraph roots fit into this round yet,
-            // so we're simply writing the first one in here, since we know
-            // at least one block will be written (and it'll be that one).
-            subgraph_roots.iter().take(1).cloned().collect(),
-        ),
-        Vec::new(),
-    );
+    let stream = stream_blocks_from_roots(subgraph_roots, bloom, store, cache);
 
-    write_blocks_into_car(
-        &mut writer,
-        subgraph_roots,
-        &bloom,
-        config.send_minimum,
-        store,
-        cache,
-    )
-    .await?;
-
-    Ok(CarFile {
-        bytes: writer.finish().await?.into(),
-    })
+    Ok(Box::pin(stream))
 }
 
 /// This function is run on the block receiving end of the protocol.
@@ -149,51 +157,70 @@ pub async fn block_receive(
         .await?;
     }
 
-    let missing_subgraph_roots = dag_verification
-        .want_cids
-        .iter()
-        .take(config.max_roots_per_round)
-        .cloned()
-        .collect();
+    let mut receiver_state = dag_verification.into_receiver_state(config.bloom_fpr);
 
-    let bloom_capacity = dag_verification.have_cids.len() as u64;
+    receiver_state
+        .missing_subgraph_roots
+        .truncate(config.max_roots_per_round);
 
-    if bloom_capacity == 0 {
-        return Ok(ReceiverState {
-            missing_subgraph_roots,
-            have_cids_bloom: None,
-        });
-    }
+    Ok(receiver_state)
+}
 
-    if missing_subgraph_roots.is_empty() {
-        // We're done. No need to compute a bloom.
-        return Ok(ReceiverState {
-            missing_subgraph_roots,
-            have_cids_bloom: None,
-        });
-    }
+/// TODO(matheus23): Docs
+#[instrument(skip_all, fields(root))]
+pub async fn block_receive_car_stream<R: tokio::io::AsyncRead + Unpin + CondSend>(
+    root: Cid,
+    reader: R,
+    config: &Config,
+    store: &impl BlockStore,
+    cache: &impl Cache,
+) -> Result<ReceiverState, Error> {
+    let reader = CarReader::new(reader).await?;
 
-    let mut bloom =
-        BloomFilter::new_from_fpr_po2(bloom_capacity, (config.bloom_fpr)(bloom_capacity));
-
-    dag_verification
-        .have_cids
-        .iter()
-        .for_each(|cid| bloom.insert(&cid.to_bytes()));
-
-    debug!(
-        inserted_elements = bloom_capacity,
-        size_bits = bloom.as_bytes().len() * 8,
-        hash_count = bloom.hash_count(),
-        ones_count = bloom.count_ones(),
-        estimated_fpr = bloom.current_false_positive_rate(),
-        "built 'have cids' bloom",
+    let mut stream: BlockStream<'_> = Box::pin(
+        reader
+            .stream()
+            .map_ok(|(cid, bytes)| (cid, Bytes::from(bytes)))
+            .map_err(Error::CarFileError),
     );
 
-    Ok(ReceiverState {
-        missing_subgraph_roots,
-        have_cids_bloom: Some(bloom),
-    })
+    block_receive_block_stream(root, &mut stream, config, store, cache).await
+}
+
+/// Consumes a stream of blocks, verifying their integrity and
+/// making sure all blocks are part of the DAG.
+pub async fn block_receive_block_stream(
+    root: Cid,
+    stream: &mut BlockStream<'_>,
+    config: &Config,
+    store: &impl BlockStore,
+    cache: &impl Cache,
+) -> Result<ReceiverState, Error> {
+    let mut dag_verification = IncrementalDagVerification::new([root], store, cache).await?;
+
+    while let Some(block) = stream.try_next().await? {
+        match read_and_verify_block(&mut dag_verification, block, store, cache).await? {
+            BlockState::Have => {
+                // This can happen because we've just discovered a subgraph we already have.
+                // Let's update the endpoint with our new receiver state.
+                break;
+            }
+            BlockState::Unexpected => {
+                // We received a block out-of-order. This is weird, but can
+                // happen due to bloom filter false positives.
+                // Essentially, the sender could've skipped a block that was
+                // important for us to verify that further blocks are connected
+                // to the root.
+                // We should update the endpoint about the skipped block.
+                break;
+            }
+            BlockState::Want => {
+                // Perfect, we're just getting what we want. Let's continue!
+            }
+        }
+    }
+
+    Ok(dag_verification.into_receiver_state(config.bloom_fpr))
 }
 
 /// Find all CIDs that a block references.
@@ -216,7 +243,7 @@ pub fn references<E: Extend<Cid>>(
 }
 
 //--------------------------------------------------------------------------------------------------
-// Private Functions
+// Private
 //--------------------------------------------------------------------------------------------------
 
 async fn verify_missing_subgraph_roots(
@@ -264,48 +291,77 @@ fn handle_missing_bloom(have_cids_bloom: Option<BloomFilter>) -> BloomFilter {
     have_cids_bloom.unwrap_or_else(|| BloomFilter::new_with(1, Box::new([0]))) // An empty bloom that contains nothing
 }
 
-async fn write_blocks_into_car<W: tokio::io::AsyncWrite + Unpin + Send>(
-    writer: &mut CarWriter<W>,
+fn stream_blocks_from_roots<'a>(
     subgraph_roots: Vec<Cid>,
-    bloom: &BloomFilter,
-    send_minimum: usize,
-    store: &impl BlockStore,
-    cache: &impl Cache,
-) -> Result<(), Error> {
+    bloom: BloomFilter,
+    store: &'a impl BlockStore,
+    cache: &'a impl Cache,
+) -> BlockStream<'a> {
+    Box::pin(
+        DagWalk::breadth_first(subgraph_roots.clone())
+            .stream(store, cache)
+            .try_filter(move |cid| {
+                future::ready(should_block_be_skipped(cid, &bloom, &subgraph_roots))
+            })
+            .and_then(move |cid| async move {
+                let bytes = store
+                    .get_block(&cid)
+                    .await
+                    .map_err(Error::BlockStoreError)?;
+                Ok((cid, bytes))
+            }),
+    )
+}
+
+async fn write_blocks_into_car<W: tokio::io::AsyncWrite + Unpin + Send>(
+    write: W,
+    blocks: &mut BlockStream<'_>,
+    receive_limit: Option<usize>,
+) -> Result<W, Error> {
     let mut block_bytes = 0;
-    let mut dag_walk = DagWalk::breadth_first(subgraph_roots.clone());
 
-    while let Some(cid) = dag_walk.next(store, cache).await? {
-        let block = store
-            .get_block(&cid)
-            .await
-            .map_err(Error::BlockStoreError)?;
+    // https://github.com/wnfs-wg/car-mirror-spec/issues/6
+    // CAR files *must* have at least one CID in them, and all of them
+    // need to appear as a block in the payload.
+    // It would probably make most sense to just write all subgraph roots into this,
+    // but we don't know how many of the subgraph roots fit into this round yet,
+    // so we're simply writing the first one in here, since we know
+    // at least one block will be written (and it'll be that one).
+    let Some((cid, block)) = blocks.try_next().await? else {
+        debug!("No blocks to write.");
+        return Ok(write);
+    };
 
-        if bloom.contains(&cid.to_bytes()) && !subgraph_roots.contains(&cid) {
-            debug!(
-                cid = %cid,
-                bloom_contains = bloom.contains(&cid.to_bytes()),
-                subgraph_roots_contains = subgraph_roots.contains(&cid),
-                "skipped writing block"
-            );
-            continue;
-        }
+    let mut writer = CarWriter::new(CarHeader::new_v1(vec![cid]), write);
 
+    block_bytes += writer.write(cid, block).await?;
+
+    while let Some((cid, block)) = blocks.try_next().await? {
         debug!(
             cid = %cid,
             num_bytes = block.len(),
-            frontier_size = dag_walk.frontier.len(),
             "writing block to CAR",
         );
 
-        block_bytes += writer.write(cid, &block).await?;
+        // Let's be conservative, assume a 64-byte CID (usually ~40 byte)
+        // and a 4-byte frame size varint (3 byte would be enough for an 8MiB frame).
+        let added_bytes = 64 + 4 + block.len();
 
-        if block_bytes > send_minimum {
-            break;
+        if let Some(receive_limit) = receive_limit {
+            if block_bytes + added_bytes > receive_limit {
+                debug!(%cid, receive_limit, block_bytes, added_bytes, "Skipping block because it would go over the receive limit");
+                break;
+            }
         }
+
+        block_bytes += writer.write(cid, &block).await?;
     }
 
-    Ok(())
+    Ok(writer.finish().await?)
+}
+
+fn should_block_be_skipped(cid: &Cid, bloom: &BloomFilter, subgraph_roots: &[Cid]) -> bool {
+    bloom.contains(&cid.to_bytes()) && !subgraph_roots.contains(cid)
 }
 
 async fn read_and_verify_blocks<R: tokio::io::AsyncRead + Unpin>(
@@ -333,24 +389,43 @@ async fn read_and_verify_blocks<R: tokio::io::AsyncRead + Unpin>(
             });
         }
 
-        match dag_verification.block_state(cid) {
-            BlockState::Have => continue,
-            BlockState::Unexpected => {
-                trace!(
-                    cid = %cid,
-                    "received block out of order (possibly due to bloom false positive)"
-                );
-                break;
-            }
-            BlockState::Want => {
-                dag_verification
-                    .verify_and_store_block((cid, block), store, cache)
-                    .await?;
-            }
+        let block_state =
+            read_and_verify_block(dag_verification, (cid, block), store, cache).await?;
+
+        if matches!(block_state, BlockState::Unexpected) {
+            break;
         }
     }
 
     Ok(())
+}
+
+/// Returns whether to continue receiving blocks.
+///
+/// Only returns false when a block was received out of order
+/// (or perhaps because a block was skipped due to a bloom filter false positive).
+async fn read_and_verify_block(
+    dag_verification: &mut IncrementalDagVerification,
+    (cid, block): (Cid, Bytes),
+    store: &impl BlockStore,
+    cache: &impl Cache,
+) -> Result<BlockState, Error> {
+    match dag_verification.block_state(cid) {
+        BlockState::Have => Ok(BlockState::Have),
+        BlockState::Unexpected => {
+            trace!(
+                cid = %cid,
+                "received block out of order (possibly due to bloom false positive)"
+            );
+            Ok(BlockState::Unexpected)
+        }
+        BlockState::Want => {
+            dag_verification
+                .verify_and_store_block((cid, block), store, cache)
+                .await?;
+            Ok(BlockState::Want)
+        }
+    }
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -443,9 +518,8 @@ impl ReceiverState {
 impl Default for Config {
     fn default() -> Self {
         Self {
-            send_minimum: 128 * 1024,    // 128KiB
-            receive_maximum: 512 * 1024, // 512KiB
-            max_roots_per_round: 1000,   // max. ~41KB of CIDs
+            receive_maximum: 2_000_000, // 2 MB
+            max_roots_per_round: 1000,  // max. ~41KB of CIDs
             bloom_fpr: |num_of_elems| f64::min(0.001, 0.1 / num_of_elems as f64),
         }
     }

--- a/car-mirror/src/common.rs
+++ b/car-mirror/src/common.rs
@@ -301,7 +301,7 @@ fn stream_blocks_from_roots<'a>(
         DagWalk::breadth_first(subgraph_roots.clone())
             .stream(store, cache)
             .try_filter(move |cid| {
-                future::ready(should_block_be_skipped(cid, &bloom, &subgraph_roots))
+                future::ready(!should_block_be_skipped(cid, &bloom, &subgraph_roots))
             })
             .and_then(move |cid| async move {
                 let bytes = store

--- a/car-mirror/src/dag_walk.rs
+++ b/car-mirror/src/dag_walk.rs
@@ -130,13 +130,13 @@ impl DagWalk {
 mod tests {
     use super::*;
     use crate::traits::NoCache;
-    use anyhow::Result;
     use futures::TryStreamExt;
     use libipld::Ipld;
+    use testresult::TestResult;
     use wnfs_common::MemoryBlockStore;
 
-    #[async_std::test]
-    async fn test_walk_dag_breadth_first() -> Result<()> {
+    #[test_log::test(async_std::test)]
+    async fn test_walk_dag_breadth_first() -> TestResult {
         let store = &MemoryBlockStore::new();
 
         // cid_root ---> cid_1_wrap ---> cid_1

--- a/car-mirror/src/pull.rs
+++ b/car-mirror/src/pull.rs
@@ -54,6 +54,7 @@ mod tests {
     use futures::TryStreamExt;
     use libipld::Cid;
     use std::collections::HashSet;
+    use testresult::TestResult;
     use wnfs_common::{BlockStore, MemoryBlockStore};
 
     pub(crate) async fn simulate_protocol(
@@ -85,8 +86,8 @@ mod tests {
         Ok(metrics)
     }
 
-    #[async_std::test]
-    async fn test_transfer() -> Result<()> {
+    #[test_log::test(async_std::test)]
+    async fn test_transfer() -> TestResult {
         let client_store = &MemoryBlockStore::new();
         let (root, ref server_store) = setup_random_dag(256, 10 * 1024 /* 10 KiB */).await?;
 

--- a/car-mirror/src/push.rs
+++ b/car-mirror/src/push.rs
@@ -64,6 +64,7 @@ mod tests {
     use libipld::Cid;
     use proptest::collection::vec;
     use std::collections::HashSet;
+    use testresult::TestResult;
     use wnfs_common::{BlockStore, MemoryBlockStore};
 
     pub(crate) async fn simulate_protocol(
@@ -95,8 +96,8 @@ mod tests {
         Ok(metrics)
     }
 
-    #[async_std::test]
-    async fn test_transfer() -> Result<()> {
+    #[test_log::test(async_std::test)]
+    async fn test_transfer() -> TestResult {
         let (root, ref client_store) = setup_random_dag(256, 10 * 1024 /* 10 KiB */).await?;
         let server_store = &MemoryBlockStore::new();
         simulate_protocol(root, &Config::default(), client_store, server_store).await?;
@@ -116,8 +117,8 @@ mod tests {
         Ok(())
     }
 
-    #[async_std::test]
-    async fn test_deduplicating_transfer() -> Result<()> {
+    #[test_log::test(async_std::test)]
+    async fn test_deduplicating_transfer() -> TestResult {
         let (root, ref client_store) = setup_random_dag(256, 10 * 1024 /* 10 KiB */).await?;
         let total_bytes = total_dag_bytes(root, client_store).await?;
         let path = Rvg::new().sample(&vec(0usize..128, 0..64));
@@ -140,8 +141,8 @@ mod tests {
         Ok(())
     }
 
-    #[async_std::test]
-    async fn print_metrics() -> Result<()> {
+    #[test_log::test(async_std::test)]
+    async fn print_metrics() -> TestResult {
         const TESTS: usize = 200;
         const DAG_SIZE: u16 = 256;
         const BLOCK_PADDING: usize = 10 * 1024;

--- a/car-mirror/src/traits.rs
+++ b/car-mirror/src/traits.rs
@@ -191,7 +191,7 @@ mod quick_cache_tests {
     use testresult::TestResult;
     use wnfs_common::{BlockStore, MemoryBlockStore};
 
-    #[async_std::test]
+    #[test_log::test(async_std::test)]
     async fn test_has_block_cache() -> TestResult {
         let store = &MemoryBlockStore::new();
         let cache = InMemoryCache::new(10_000, 150_000);
@@ -212,7 +212,7 @@ mod quick_cache_tests {
         Ok(())
     }
 
-    #[async_std::test]
+    #[test_log::test(async_std::test)]
     async fn test_references_cache() -> TestResult {
         let store = &MemoryBlockStore::new();
         let cache = InMemoryCache::new(10_000, 150_000);
@@ -289,7 +289,7 @@ mod tests {
         }
     }
 
-    #[async_std::test]
+    #[test_log::test(async_std::test)]
     async fn test_has_block_cache() -> TestResult {
         let store = &MemoryBlockStore::new();
         let cache = HashMapCache::default();
@@ -310,7 +310,7 @@ mod tests {
         Ok(())
     }
 
-    #[async_std::test]
+    #[test_log::test(async_std::test)]
     async fn test_references_cache() -> TestResult {
         let store = &MemoryBlockStore::new();
         let cache = HashMapCache::default();
@@ -346,7 +346,7 @@ mod tests {
         Ok(())
     }
 
-    #[async_std::test]
+    #[test_log::test(async_std::test)]
     async fn test_no_cache_has_block() -> TestResult {
         let store = &MemoryBlockStore::new();
         let cache = NoCache;
@@ -372,7 +372,7 @@ mod tests {
         Ok(())
     }
 
-    #[async_std::test]
+    #[test_log::test(async_std::test)]
     async fn test_no_cache_references() -> TestResult {
         let store = &MemoryBlockStore::new();
         let cache = NoCache;


### PR DESCRIPTION
Implements streaming the CAR file that's generated in a response and consuming a response CAR stream.

This is not doing full-duplex streaming yet, but the difference shouldn't be too big.

This has helped cold sync in appa a lot, since it reduces the amount of round-trips to one and streams all bytes needed for sync in one go.
