### PR TITLE
feat: Create `car-mirror-reqwest` crate & add high-level streaming functions

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -37,7 +37,7 @@ jobs:
           RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off'
           RUSTDOCFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off'
         ## currently just runs coverage on rust project
-        run: cargo test -p car-mirror --all-features
+        run: cargo test --all-features
 
       - name: Install grcov
         run: "curl -L https://github.com/mozilla/grcov/releases/download/v0.8.12/grcov-x86_64-unknown-linux-gnu.tar.bz2 | tar jxf -"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -473,9 +473,11 @@ dependencies = [
  "testresult",
  "thiserror",
  "tokio",
+ "tokio-util",
  "tracing",
  "tracing-subscriber",
  "wnfs-common",
+ "wnfs-unixfs-file",
 ]
 
 [[package]]
@@ -1636,6 +1638,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
+dependencies = [
+ "num_enum_derive",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "object"
 version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1823,6 +1846,29 @@ dependencies = [
  "rusty-fork",
  "tempfile",
  "unarray",
+]
+
+[[package]]
+name = "prost"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c289cda302b98a28d40c8b3b90498d6e526dd24ac2ecea73e4e491685b94a"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efb6c9a1dd1def8e2124d17e83a20af56f1570d6c2d2bd9e266ccb768df3840e"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -3118,6 +3164,25 @@ dependencies = [
  "serde",
  "serde_ipld_dagcbor",
  "thiserror",
+]
+
+[[package]]
+name = "wnfs-unixfs-file"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf5f1e8e6537a38c0e662a5cb4524bf6bec7d2c0d5e37f8a3849e7eedb212312"
+dependencies = [
+ "anyhow",
+ "async-stream",
+ "bytes",
+ "futures",
+ "libipld",
+ "num_enum",
+ "prost",
+ "rand_core",
+ "testresult",
+ "tokio",
+ "wnfs-common",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,7 +157,7 @@ dependencies = [
  "polling 2.8.0",
  "rustix 0.37.27",
  "slab",
- "socket2",
+ "socket2 0.4.10",
  "waker-fn",
 ]
 
@@ -262,6 +262,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbb36e985947064623dbd357f727af08ffd077f93d696782f3c56365fa2e2799"
 
 [[package]]
+name = "async-trait"
+version = "0.1.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -304,6 +315,12 @@ name = "base-x"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
+
+[[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "bit-set"
@@ -476,6 +493,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "car-mirror-reqwest"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-std",
+ "bytes",
+ "car-mirror",
+ "futures",
+ "libipld",
+ "reqwest",
+ "reqwest-middleware",
+ "test-log",
+ "test-strategy",
+ "testresult",
+ "thiserror",
+ "tokio-util",
+ "tracing",
+ "tracing-subscriber",
+ "wnfs-common",
+]
+
+[[package]]
 name = "car-mirror-wasm"
 version = "0.1.0"
 dependencies = [
@@ -579,7 +618,7 @@ checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
 dependencies = [
  "bitflags 1.3.2",
  "clap_lex",
- "indexmap",
+ "indexmap 1.9.3",
  "textwrap",
 ]
 
@@ -616,6 +655,16 @@ name = "constant_time_eq"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "core-foundation-sys"
@@ -774,6 +823,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -864,6 +922,15 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "funty"
@@ -1028,6 +1095,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap 2.2.3",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "half"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1065,6 +1151,78 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd5256b483761cd23699d0da46cc6fd2ee3be420bbe6d020ae4a091e70b7e9fd"
 
 [[package]]
+name = "http"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8947b1a6fad4393052c7ba1f4cd97bed3e953a95c79c92ad9b051a04611d9fbb"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "0.14.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf96e135eb83a2a8ddf766e426a841d8ddd7449d5f00d34ea02b41d2f19eef80"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.5.5",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+dependencies = [
+ "futures-util",
+ "http",
+ "hyper",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+]
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1088,6 +1246,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "idna"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1095,6 +1263,16 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233cf39063f058ea2caae4091bf4a3ef70a653afbc026f5c4a4135d114e3c177"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.3",
 ]
 
 [[package]]
@@ -1116,6 +1294,12 @@ dependencies = [
  "libc",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
 name = "iroh-car"
@@ -1352,12 +1536,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
 dependencies = [
  "adler",
+]
+
+[[package]]
+name = "mio"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1485,6 +1696,12 @@ dependencies = [
  "smallvec",
  "windows-targets 0.48.5",
 ]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pin-project-lite"
@@ -1743,6 +1960,80 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
+name = "reqwest"
+version = "0.11.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6920094eb85afde5e4a138be3f2de8bbdf28000f0029e72c45025a56b042251"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-rustls",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "mime_guess",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "system-configuration",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+ "webpki-roots",
+ "winreg",
+]
+
+[[package]]
+name = "reqwest-middleware"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a3e86aa6053e59030e7ce2d2a3b258dd08fc2d337d52f73f6cb480f5858690"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "http",
+ "reqwest",
+ "serde",
+ "task-local-extensions",
+ "thiserror",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom",
+ "libc",
+ "spin",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "roaring"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1798,6 +2089,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.21.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki",
+ "sct",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+dependencies = [
+ "base64",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
 name = "rusty-fork"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1835,6 +2157,16 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "serde"
@@ -1898,6 +2230,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1953,6 +2297,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
+dependencies = [
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
 name = "structmeta"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1998,6 +2358,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
 name = "synstructure"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2010,10 +2376,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "task-local-extensions"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba323866e5d033818e3240feeb9f7db2c4296674e4d9e16b97b7bf8f490434e8"
+dependencies = [
+ "pin-utils",
+]
 
 [[package]]
 name = "tempfile"
@@ -2113,6 +2509,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2120,7 +2531,35 @@ checksum = "61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931"
 dependencies = [
  "backtrace",
  "bytes",
+ "libc",
+ "mio",
  "pin-project-lite",
+ "socket2 0.5.5",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -2131,6 +2570,12 @@ checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "tower-service"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
@@ -2208,6 +2653,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2220,10 +2671,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
+name = "unicase"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-width"
@@ -2242,6 +2717,23 @@ name = "unsigned-varint"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6889a77d49f1f013504cec6bf97a2c730394adedaeb1deb5ea08949a50541105"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
 
 [[package]]
 name = "valuable"
@@ -2284,6 +2776,15 @@ checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
 dependencies = [
  "same-file",
  "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
 ]
 
 [[package]]
@@ -2386,6 +2887,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b65dc4c90b63b118468cf747d8bf3566c1913ef60be765b5730ead9e0a3ba129"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2394,6 +2908,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "webpki-roots"
+version = "0.25.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "winapi"
@@ -2566,6 +3086,16 @@ name = "windows_x86_64_msvc"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+
+[[package]]
+name = "winreg"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "wnfs-common"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -296,6 +296,73 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "axum"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1236b4b292f6c4d6dc34604bb5120d85c3fe1d1aa596bd5cc52ca054d13e7b9e"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http 1.0.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "hyper 1.1.0",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15c63fd72d41492dc4f497196f5da1fb04fb7529e631d73630d1b491e47a2e3"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http 1.0.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00c055ee2d014ae5981ce1016374e8213682aa14d9bf40e48ab48b5f3ef20eaa"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -499,7 +566,8 @@ name = "car-mirror-reqwest"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-std",
+ "axum",
+ "axum-macros",
  "bytes",
  "car-mirror",
  "futures",
@@ -510,6 +578,7 @@ dependencies = [
  "test-strategy",
  "testresult",
  "thiserror",
+ "tokio",
  "tokio-util",
  "tracing",
  "tracing-subscriber",
@@ -1107,7 +1176,26 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 0.2.11",
+ "indexmap 2.2.3",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31d030e59af851932b72ceebadf4a2b5986dba4c3b99dd2493f8273a0f151943"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 1.0.0",
  "indexmap 2.2.3",
  "slab",
  "tokio",
@@ -1138,6 +1226,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 
 [[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1164,13 +1258,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b32afd38673a8016f7c9ae69e5af41a58f81b1d31689040f2f1959594ce194ea"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http-body"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
 dependencies = [
  "bytes",
- "http",
+ "http 0.2.11",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+dependencies = [
+ "bytes",
+ "http 1.0.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41cb79eb393015dadd30fc252023adb0b2400a0caee0fa2a077e6e21a551e840"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http 1.0.0",
+ "http-body 1.0.0",
  "pin-project-lite",
 ]
 
@@ -1196,9 +1324,9 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
+ "h2 0.3.24",
+ "http 0.2.11",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
@@ -1211,17 +1339,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5aa53871fc917b1a9ed87b683a5d86db645e23acb32c2e0785a353e522fb75"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "h2 0.4.2",
+ "http 1.0.0",
+ "http-body 1.0.0",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
- "http",
- "hyper",
+ "http 0.2.11",
+ "hyper 0.14.28",
  "rustls",
  "tokio",
  "tokio-rustls",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca38ef113da30126bbff9cd1705f9273e15d45498615d138b0c20279ac7a76aa"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http 1.0.0",
+ "http-body 1.0.0",
+ "hyper 1.1.0",
+ "pin-project-lite",
+ "socket2 0.5.5",
+ "tokio",
 ]
 
 [[package]]
@@ -1509,6 +1672,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
 name = "memchr"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1638,6 +1807,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+dependencies = [
+ "hermit-abi 0.3.6",
+ "libc",
+]
+
+[[package]]
 name = "num_enum"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1725,6 +1904,26 @@ name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "pin-project"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0302c4a0442c456bd56f841aee5c3bfd17967563f6fadc9ceb9f9c23cf3807e0"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "266c042b60c9c76b8d53061e52b2e0d1116abc57cefc8c5cd671619a56ac3690"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -2016,10 +2215,10 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
- "hyper",
+ "h2 0.3.24",
+ "http 0.2.11",
+ "http-body 0.4.6",
+ "hyper 0.14.28",
  "hyper-rustls",
  "ipnet",
  "js-sys",
@@ -2057,7 +2256,7 @@ checksum = "88a3e86aa6053e59030e7ce2d2a3b258dd08fc2d337d52f73f6cb480f5858690"
 dependencies = [
  "anyhow",
  "async-trait",
- "http",
+ "http 0.2.11",
  "reqwest",
  "serde",
  "task-local-extensions",
@@ -2164,6 +2363,12 @@ dependencies = [
  "ring",
  "untrusted",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
 name = "rusty-fork"
@@ -2276,6 +2481,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebd154a240de39fdebcf5775d2675c204d7c13cf39a4c697be6493c8e734337c"
+dependencies = [
+ "itoa",
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2315,6 +2530,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -2579,9 +2803,24 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "num_cpus",
+ "parking_lot",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2 0.5.5",
+ "tokio-macros",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -2618,6 +2857,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+
+[[package]]
 name = "tower-service"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2629,6 +2890,7 @@ version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,6 +79,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
+name = "assert_matches"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
+
+[[package]]
 name = "async-attributes"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -521,6 +527,7 @@ name = "car-mirror"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "assert_matches",
  "async-std",
  "async-stream",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,9 @@
 members = [
 	"car-mirror",
 	"car-mirror-benches",
+	"car-mirror-reqwest",
 	"car-mirror-wasm",
-	"examples"
+	"examples",
 ]
 
 [workspace.dependencies]

--- a/car-mirror-reqwest/.dockerignore
+++ b/car-mirror-reqwest/.dockerignore
@@ -1,0 +1,7 @@
+*
+
+!Cargo.lock
+!Cargo.toml
+!src
+
+src/bin

--- a/car-mirror-reqwest/Cargo.toml
+++ b/car-mirror-reqwest/Cargo.toml
@@ -23,18 +23,22 @@ bytes = "1.4"
 car-mirror = { version = "0.1", path = "../car-mirror" }
 futures = "0.3"
 libipld = "0.16"
-reqwest = { version = "0.11.22", default-features = false, features = ["json", "rustls-tls", "stream"] }
-reqwest-middleware = "0.2.4"
+reqwest = { version = "0.11", default-features = false, features = ["json", "stream"] }
+reqwest-middleware = "0.2"
 thiserror = "1.0"
-tokio-util = "0.7"
+tokio-util = { version = "0.7", features = ["io"] }
 tracing = "0.1"
 wnfs-common = { workspace = true }
 
 [dev-dependencies]
-async-std = { version = "1.11", features = ["attributes"] }
+axum = "0.7"
+axum-macros = "0.4"
+car-mirror = { version = "0.1", path = "../car-mirror", features = ["quick_cache"] }
+reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls", "stream"] }
 test-log = { version = "0.2", default-features = false, features = ["trace"] }
 test-strategy = "0.3"
 testresult = "0.3"
+tokio = { version = "1.0", features = ["full"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json", "parking_lot", "registry"] }
 
 [features]

--- a/car-mirror-reqwest/Cargo.toml
+++ b/car-mirror-reqwest/Cargo.toml
@@ -1,0 +1,45 @@
+[package]
+name = "car-mirror-reqwest"
+version = "0.1.0"
+description = "Adapter for using car-mirror with reqwest-middleware"
+keywords = []
+categories = []
+include = ["/src", "README.md", "LICENSE-APACHE", "LICENSE-MIT"]
+license = "Apache-2.0"
+readme = "README.md"
+edition = "2021"
+rust-version = "1.66"
+documentation = "https://docs.rs/car-mirror-reqwest"
+repository = "https://github.com/fission-codes/rs-car-mirror/tree/main/car-mirror-reqwest"
+authors = ["Philipp Krüger <philipp@fission.codes>"]
+
+[lib]
+path = "src/lib.rs"
+doctest = true
+
+[dependencies]
+anyhow = "1.0"
+bytes = "1.4"
+car-mirror = { version = "0.1", path = "../car-mirror" }
+futures = "0.3"
+libipld = "0.16"
+reqwest = { version = "0.11.22", default-features = false, features = ["json", "rustls-tls", "stream"] }
+reqwest-middleware = "0.2.4"
+thiserror = "1.0"
+tokio-util = "0.7"
+tracing = "0.1"
+wnfs-common = { workspace = true }
+
+[dev-dependencies]
+async-std = { version = "1.11", features = ["attributes"] }
+test-log = { version = "0.2", default-features = false, features = ["trace"] }
+test-strategy = "0.3"
+testresult = "0.3"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "json", "parking_lot", "registry"] }
+
+[features]
+
+[package.metadata.docs.rs]
+all-features = true
+# defines the configuration attribute `docsrs`
+rustdoc-args = ["--cfg", "docsrs"]

--- a/car-mirror-reqwest/Cargo.toml
+++ b/car-mirror-reqwest/Cargo.toml
@@ -47,3 +47,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "json", "parki
 all-features = true
 # defines the configuration attribute `docsrs`
 rustdoc-args = ["--cfg", "docsrs"]
+
+[[test]]
+name = "integration"
+path = "integration/axum.rs"

--- a/car-mirror-reqwest/LICENSE-APACHE
+++ b/car-mirror-reqwest/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/car-mirror-reqwest/LICENSE-MIT
+++ b/car-mirror-reqwest/LICENSE-MIT
@@ -1,0 +1,23 @@
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/car-mirror-reqwest/README.md
+++ b/car-mirror-reqwest/README.md
@@ -1,0 +1,53 @@
+<div align="center">
+  <h1 align="center">car-mirror-reqwest</h1>
+
+  <p>
+    <a href="https://crates.io/crates/car-mirror-reqwest">
+      <img src="https://img.shields.io/crates/v/car-mirror-reqwest?label=crates" alt="Crate">
+    </a>
+    <a href="https://codecov.io/gh/fission-codes/rs-car-mirror">
+      <img src="https://codecov.io/gh/fission-codes/rs-car-mirror/branch/main/graph/badge.svg?token=SOMETOKEN" alt="Code Coverage"/>
+    </a>
+    <a href="https://github.com/fission-codes/rs-car-mirror/actions?query=">
+      <img src="https://github.com/fission-codes/rs-car-mirror/actions/workflows/tests_and_checks.yml/badge.svg" alt="Build Status">
+    </a>
+    <a href="https://github.com/fission-codes/rs-car-mirror/blob/main/LICENSE-APACHE">
+      <img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg" alt="License-Apache">
+    </a>
+    <a href="https://github.com/fission-codes/rs-car-mirror/blob/main/LICENSE-MIT">
+      <img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="License-MIT">
+    </a>
+    <a href="https://docs.rs/car-mirror-reqwest">
+      <img src="https://img.shields.io/static/v1?label=Docs&message=docs.rs&color=blue" alt="Docs">
+    </a>
+    <a href="https://discord.com/invite/zAQBDEq">
+      <img src="https://img.shields.io/static/v1?label=Discord&message=join%20us!&color=mediumslateblue" alt="Discord">
+    </a>
+  </p>
+</div>
+
+<div align="center"><sub>:warning: Work in progress :warning:</sub></div>
+
+## car-mirror-reqwest
+
+Description.
+
+## License
+
+This project is licensed under either of
+
+- Apache License, Version 2.0, ([LICENSE-APACHE](./LICENSE-APACHE) or [http://www.apache.org/licenses/LICENSE-2.0][apache])
+- MIT license ([LICENSE-MIT](./LICENSE-MIT) or [http://opensource.org/licenses/MIT][mit])
+
+at your option.
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally
+submitted for inclusion in the work by you, as defined in the Apache-2.0
+license, shall be dual licensed as above, without any additional terms or
+conditions.
+
+
+[apache]: https://www.apache.org/licenses/LICENSE-2.0
+[mit]: http://opensource.org/licenses/MIT

--- a/car-mirror-reqwest/examples/axum.rs
+++ b/car-mirror-reqwest/examples/axum.rs
@@ -1,0 +1,146 @@
+use anyhow::Result;
+use axum::{
+    body::Body,
+    extract::{Path, State},
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    routing::{get, post},
+    Json, Router,
+};
+use car_mirror::{
+    cache::{InMemoryCache, NoCache},
+    common::Config,
+    messages::{PullRequest, PushResponse},
+};
+use car_mirror_reqwest::RequestBuilderExt;
+use futures::TryStreamExt;
+use libipld::Cid;
+use reqwest::Client;
+use std::{future::IntoFuture, str::FromStr};
+use tokio_util::io::StreamReader;
+use wnfs_common::{BlockStore, MemoryBlockStore, CODEC_RAW};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Say, you have a webserver running like so:
+    let app = Router::new()
+        .route("/dag/pull/:cid", get(car_mirror_pull))
+        .route("/dag/push/:cid", post(car_mirror_push))
+        .with_state(ServerState::new());
+
+    let listener = tokio::net::TcpListener::bind("0.0.0.0:3344").await?;
+    tokio::spawn(axum::serve(listener, app).into_future());
+
+    // You can issue requests from your client like so:
+    let store = MemoryBlockStore::new();
+    let data = b"Hello, world!".to_vec();
+    let root = store.put_block(data, CODEC_RAW).await?;
+
+    let config = &Config::default();
+
+    let client = Client::new();
+    client
+        .post(format!("http://localhost:3344/dag/push/{root}"))
+        .run_car_mirror_push(root, &store, &NoCache) // rounds of push protocol
+        .await?;
+
+    let store = MemoryBlockStore::new(); // clear out data
+    client
+        .get(format!("http://localhost:3344/dag/pull/{root}"))
+        .run_car_mirror_pull(root, config, &store, &NoCache) // rounds of pull protocol
+        .await?;
+
+    assert!(store.has_block(&root).await?);
+
+    Ok(())
+}
+
+// Server details:
+
+#[derive(Debug, Clone)]
+struct ServerState {
+    store: MemoryBlockStore,
+    cache: InMemoryCache,
+}
+
+impl ServerState {
+    fn new() -> Self {
+        Self {
+            store: MemoryBlockStore::new(),
+            cache: InMemoryCache::new(100_000),
+        }
+    }
+}
+
+#[axum_macros::debug_handler]
+async fn car_mirror_push(
+    State(state): State<ServerState>,
+    Path(cid_string): Path<String>,
+    body: Body,
+) -> Result<(StatusCode, Json<PushResponse>), AppError>
+where {
+    let cid = Cid::from_str(&cid_string)?;
+
+    let body_stream = body.into_data_stream();
+
+    let reader = StreamReader::new(
+        body_stream.map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e)),
+    );
+
+    let response = car_mirror::push::response_streaming(
+        cid,
+        reader,
+        &Config::default(),
+        &state.store,
+        &state.cache,
+    )
+    .await?;
+
+    if response.indicates_finished() {
+        Ok((StatusCode::OK, Json(response)))
+    } else {
+        Ok((StatusCode::ACCEPTED, Json(response)))
+    }
+}
+
+#[axum_macros::debug_handler]
+async fn car_mirror_pull(
+    State(state): State<ServerState>,
+    Path(cid_string): Path<String>,
+    Json(request): Json<PullRequest>,
+) -> Result<(StatusCode, Body), AppError> {
+    let cid = Cid::from_str(&cid_string)?;
+
+    let car_chunks = car_mirror::pull::response_streaming(
+        cid,
+        request,
+        state.store.clone(),
+        state.cache.clone(),
+    )
+    .await?;
+
+    Ok((StatusCode::OK, Body::from_stream(car_chunks)))
+}
+
+// Basic anyhow error handling:
+
+struct AppError(anyhow::Error);
+
+impl IntoResponse for AppError {
+    fn into_response(self) -> Response {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("Something went wrong: {}", self.0),
+        )
+            .into_response()
+    }
+}
+
+impl<E> From<E> for AppError
+where
+    E: Into<anyhow::Error>,
+{
+    fn from(err: E) -> Self {
+        Self(err.into())
+    }
+}

--- a/car-mirror-reqwest/integration/axum.rs
+++ b/car-mirror-reqwest/integration/axum.rs
@@ -50,7 +50,7 @@ async fn main() -> Result<()> {
         .run_car_mirror_pull(root, config, &store, &NoCache) // rounds of pull protocol
         .await?;
 
-    assert!(!store.has_block(&root).await?);
+    assert!(store.has_block(&root).await?);
 
     Ok(())
 }

--- a/car-mirror-reqwest/integration/axum.rs
+++ b/car-mirror-reqwest/integration/axum.rs
@@ -20,7 +20,7 @@ use std::{future::IntoFuture, str::FromStr};
 use tokio_util::io::StreamReader;
 use wnfs_common::{BlockStore, MemoryBlockStore, CODEC_RAW};
 
-#[tokio::main]
+#[test_log::test(tokio::test)]
 async fn main() -> Result<()> {
     // Say, you have a webserver running like so:
     let app = Router::new()
@@ -50,7 +50,7 @@ async fn main() -> Result<()> {
         .run_car_mirror_pull(root, config, &store, &NoCache) // rounds of pull protocol
         .await?;
 
-    assert!(store.has_block(&root).await?);
+    assert!(!store.has_block(&root).await?);
 
     Ok(())
 }

--- a/car-mirror-reqwest/src/error.rs
+++ b/car-mirror-reqwest/src/error.rs
@@ -14,7 +14,7 @@ pub enum Error {
     /// `RequestBuilder::body(Body::wrap_stream(...))` was called.
     ///
     /// Generally, car-mirror-reqwest will take over body creation, so there's
-    /// no point in setting the body before `send_car_mirror_pull` / `send_car_mirror_push`.
+    /// no point in setting the body before `run_car_mirror_pull` / `run_car_mirror_push`.
     #[error("Body must not be set on request builder")]
     RequestBuilderBodyAlreadySet,
 

--- a/car-mirror-reqwest/src/error.rs
+++ b/car-mirror-reqwest/src/error.rs
@@ -1,0 +1,32 @@
+use reqwest::Response;
+
+/// Possible errors raised in this library
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    /// Raised when the HTTP response code didn't end up as a 200 or 202
+    #[error("Unexpected response code: {}, expected 200 or 202", response.status())]
+    UnexpectedStatusCode {
+        /// The response
+        response: Response,
+    },
+
+    /// Raised when `RequestBuilder::try_clone` fails, usually because
+    /// `RequestBuilder::body(Body::wrap_stream(...))` was called.
+    ///
+    /// Generally, car-mirror-reqwest will take over body creation, so there's
+    /// no point in setting the body before `send_car_mirror_pull` / `send_car_mirror_push`.
+    #[error("Body must not be set on request builder")]
+    RequestBuilderBodyAlreadySet,
+
+    /// reqwest errors
+    #[error(transparent)]
+    ReqwestError(#[from] reqwest::Error),
+
+    /// reqwest-middleware errors
+    #[error(transparent)]
+    ReqwestMiddlewareError(#[from] reqwest_middleware::Error),
+
+    /// car-mirror errors
+    #[error(transparent)]
+    CarMirrorError(#[from] car_mirror::Error),
+}

--- a/car-mirror-reqwest/src/lib.rs
+++ b/car-mirror-reqwest/src/lib.rs
@@ -1,0 +1,11 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![warn(missing_debug_implementations, missing_docs, rust_2018_idioms)]
+#![deny(unreachable_pub)]
+
+//! A helper library that helps making car-mirror client requests using reqwest
+
+mod error;
+mod request;
+
+pub use error::*;
+pub use request::*;

--- a/car-mirror-reqwest/src/lib.rs
+++ b/car-mirror-reqwest/src/lib.rs
@@ -37,7 +37,7 @@
 //! # }
 //! ```
 //!
-//! For the full example, please see `examples/axum.rs` in the source repository.
+//! For the full example, please see `integration/axum.rs` in the source repository.
 
 mod error;
 mod request;

--- a/car-mirror-reqwest/src/lib.rs
+++ b/car-mirror-reqwest/src/lib.rs
@@ -2,7 +2,42 @@
 #![warn(missing_debug_implementations, missing_docs, rust_2018_idioms)]
 #![deny(unreachable_pub)]
 
-//! A helper library that helps making car-mirror client requests using reqwest
+//! # car-mirror-reqwest
+//!
+//! A helper library that helps making car-mirror client requests using reqwest.
+//!
+//! ```no_run
+//! # use anyhow::Result;
+//! use car_mirror::{cache::NoCache, common::Config};
+//! use car_mirror_reqwest::RequestBuilderExt;
+//! use wnfs_common::{BlockStore, MemoryBlockStore, CODEC_RAW};
+//!
+//! # #[tokio::main]
+//! # async fn main() -> Result<()> {
+//! let store = MemoryBlockStore::new();
+//! let data = b"Hello, world!".to_vec();
+//! let root = store.put_block(data, CODEC_RAW).await?;
+//!
+//! let config = &Config::default();
+//!
+//! let client = reqwest::Client::new();
+//! client
+//!     .post(format!("http://localhost:3344/dag/push/{root}"))
+//!     .run_car_mirror_push(root, &store, &NoCache) // rounds of push protocol
+//!     .await?;
+//!
+//! let store = MemoryBlockStore::new(); // clear out data
+//! client
+//!     .get(format!("http://localhost:3344/dag/pull/{root}"))
+//!     .run_car_mirror_pull(root, config, &store, &NoCache) // rounds of pull protocol
+//!     .await?;
+//!
+//! assert!(store.has_block(&root).await?);
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! For the full example, please see `examples/axum.rs` in the source repository.
 
 mod error;
 mod request;

--- a/car-mirror-reqwest/src/request.rs
+++ b/car-mirror-reqwest/src/request.rs
@@ -32,7 +32,7 @@ pub trait RequestBuilderExt {
     /// lifetimes work with `reqwest`.
     /// Usually blockstores and caches satisfy these conditions due to
     /// using atomic reference counters.
-    fn send_car_mirror_push(
+    fn run_car_mirror_push(
         &self,
         root: Cid,
         store: &(impl BlockStore + Clone + 'static),
@@ -55,7 +55,7 @@ pub trait RequestBuilderExt {
     /// This will call `try_clone()` and `send()` on this
     /// request builder, so it must not have a `body` set yet.
     /// There is no need to set a body, this function will do so automatically.
-    fn send_car_mirror_pull(
+    fn run_car_mirror_pull(
         &self,
         root: Cid,
         config: &Config,
@@ -65,7 +65,7 @@ pub trait RequestBuilderExt {
 }
 
 impl RequestBuilderExt for reqwest_middleware::RequestBuilder {
-    async fn send_car_mirror_push(
+    async fn run_car_mirror_push(
         &self,
         root: Cid,
         store: &(impl BlockStore + Clone + 'static),
@@ -83,7 +83,7 @@ impl RequestBuilderExt for reqwest_middleware::RequestBuilder {
         .await
     }
 
-    async fn send_car_mirror_pull(
+    async fn run_car_mirror_pull(
         &self,
         root: Cid,
         config: &Config,
@@ -104,7 +104,7 @@ impl RequestBuilderExt for reqwest_middleware::RequestBuilder {
 }
 
 impl RequestBuilderExt for reqwest::RequestBuilder {
-    async fn send_car_mirror_push(
+    async fn run_car_mirror_push(
         &self,
         root: Cid,
         store: &(impl BlockStore + Clone + 'static),
@@ -122,7 +122,7 @@ impl RequestBuilderExt for reqwest::RequestBuilder {
         .await
     }
 
-    async fn send_car_mirror_pull(
+    async fn run_car_mirror_pull(
         &self,
         root: Cid,
         config: &Config,
@@ -144,9 +144,9 @@ impl RequestBuilderExt for reqwest::RequestBuilder {
 
 /// Run (possibly multiple rounds of) the car mirror push protocol.
 ///
-/// See `send_car_mirror_push` for a more ergonomic interface.
+/// See `run_car_mirror_push` for a more ergonomic interface.
 ///
-/// Unlike `send_car_mirror_push`, this allows customizing the
+/// Unlike `run_car_mirror_push`, this allows customizing the
 /// request every time it gets built, e.g. to refresh authentication tokens.
 pub async fn push_with<F, Fut, E>(
     root: Cid,
@@ -190,9 +190,9 @@ where
 
 /// Run (possibly multiple rounds of) the car mirror pull protocol.
 ///
-/// See `send_car_mirror_pull` for a more ergonomic interface.
+/// See `run_car_mirror_pull` for a more ergonomic interface.
 ///
-/// Unlike `send_car_mirror_pull`, this allows customizing the
+/// Unlike `run_car_mirror_pull`, this allows customizing the
 /// request every time it gets built, e.g. to refresh authentication tokens.
 pub async fn pull_with<F, Fut, E>(
     root: Cid,

--- a/car-mirror/Cargo.toml
+++ b/car-mirror/Cargo.toml
@@ -37,6 +37,7 @@ tracing = "0.1"
 wnfs-common = { workspace = true }
 
 [dev-dependencies]
+assert_matches = "1.5.0"
 async-std = { version = "1.11", features = ["attributes"] }
 car-mirror = { path = ".", features = ["quick_cache", "test_utils"] }
 proptest = "1.1"

--- a/car-mirror/Cargo.toml
+++ b/car-mirror/Cargo.toml
@@ -38,13 +38,15 @@ wnfs-common = { workspace = true }
 
 [dev-dependencies]
 async-std = { version = "1.11", features = ["attributes"] }
-car-mirror = { path = ".", features = ["test_utils"] }
+car-mirror = { path = ".", features = ["quick_cache", "test_utils"] }
 proptest = "1.1"
 roaring-graphs = "0.12"
 test-log = { version = "0.2", default-features = false, features = ["trace"] }
 test-strategy = "0.3"
 testresult = "0.3"
+tokio-util = { version = "0.7.8", features = ["io"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json", "parking_lot", "registry"] }
+wnfs-unixfs-file = { version = "0.2.0" }
 
 [features]
 default = []

--- a/car-mirror/src/cache.rs
+++ b/car-mirror/src/cache.rs
@@ -91,7 +91,7 @@ impl<C: Cache> Cache for Box<C> {
 }
 
 /// An implementation of `Cache` that doesn't cache at all.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct NoCache;
 
 impl Cache for NoCache {

--- a/car-mirror/src/common.rs
+++ b/car-mirror/src/common.rs
@@ -251,7 +251,7 @@ pub async fn block_receive_block_stream(
 
     while let Some((cid, block)) = stream.try_next().await? {
         let block_bytes = block.len();
-        // TODO: Find a way to restrict size *before* framing. Possibly inside `CarReader`?
+        // TODO(matheus23): Find a way to restrict size *before* framing. Possibly inside `CarReader`?
         // Possibly needs making `MAX_ALLOC` in `iroh-car` configurable.
         if block_bytes > config.max_block_size {
             return Err(Error::BlockSizeExceeded {

--- a/car-mirror/src/common.rs
+++ b/car-mirror/src/common.rs
@@ -619,7 +619,7 @@ impl std::fmt::Debug for ReceiverState {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::*;
     use crate::{cache::NoCache, test_utils::assert_cond_send_sync};
     use testresult::TestResult;

--- a/car-mirror/src/error.rs
+++ b/car-mirror/src/error.rs
@@ -1,7 +1,6 @@
+use crate::incremental_verification::BlockState;
 use libipld::Cid;
 use wnfs_common::BlockStoreError;
-
-use crate::incremental_verification::BlockState;
 
 /// Errors raised from the CAR mirror library
 #[derive(thiserror::Error, Debug)]
@@ -16,7 +15,7 @@ pub enum Error {
         bytes_read: usize,
     },
 
-    /// This library only supports a subset of default codecs, including DAG-CBOR, DAG-JSON, DAG-PB and more.g
+    /// This library only supports a subset of default codecs, including DAG-CBOR, DAG-JSON, DAG-PB and more.
     /// This is raised if an unknown codec is read from a CID. See the `libipld` library for more information.
     #[error("Unsupported codec in Cid: {cid}")]
     UnsupportedCodec {

--- a/car-mirror/src/error.rs
+++ b/car-mirror/src/error.rs
@@ -15,6 +15,17 @@ pub enum Error {
         bytes_read: usize,
     },
 
+    /// An error raised when an individual block exceeded the maximum configured block size
+    #[error("Maximum block size exceeded, maximum configured block size is {max_block_size} bytes, but got {block_bytes} at {cid}")]
+    BlockSizeExceeded {
+        /// The CID of the block that exceeded the maximum
+        cid: Cid,
+        /// The amount of bytes we got for this block up to this point
+        block_bytes: usize,
+        /// The maximum block size from our configuration
+        max_block_size: usize,
+    },
+
     /// This library only supports a subset of default codecs, including DAG-CBOR, DAG-JSON, DAG-PB and more.
     /// This is raised if an unknown codec is read from a CID. See the `libipld` library for more information.
     #[error("Unsupported codec in Cid: {cid}")]

--- a/car-mirror/src/lib.rs
+++ b/car-mirror/src/lib.rs
@@ -37,6 +37,200 @@ pub mod incremental_verification;
 /// Data types that are sent over-the-wire and relevant serialization code.
 pub mod messages;
 /// The CAR mirror pull protocol. Meant to be used qualified, i.e. `pull::request` and `pull::response`.
+///
+/// This library exposes both streaming and non-streaming variants. It's recommended to use
+/// the streaming variants if possible.
+///
+/// ## Examples
+///
+/// ### Test Data
+///
+/// We'll set up some test data to simulate the protocol like this:
+///
+/// ```no_run
+/// use car_mirror::cache::InMemoryCache;
+/// use wnfs_common::MemoryBlockStore;
+/// use wnfs_unixfs_file::builder::FileBuilder;
+///
+/// # #[async_std::main]
+/// # async fn main() -> anyhow::Result<()> {
+/// // We simulate peers having separate data stores
+/// let client_store = MemoryBlockStore::new();
+/// let server_store = MemoryBlockStore::new();
+///
+/// // Give both peers ~1MB of cache space for speeding up computations.
+/// // These are available under the `quick_cache` feature.
+/// // (You can also implement your own, or disable caches using `NoCache`)
+/// let client_cache = InMemoryCache::new(100_000);
+/// let server_cache = InMemoryCache::new(100_000);
+///
+/// let file_bytes = async_std::fs::read("../Cargo.lock").await?;
+///
+/// // Load some data onto the client
+/// let root = FileBuilder::new()
+///     .content_bytes(file_bytes.clone())
+///     .fixed_chunker(1024) // Generate lots of small blocks
+///     .degree(4)
+///     .build()?
+///     .store(&client_store)
+///     .await?;
+///
+/// // The server may already have a subset of the data
+/// FileBuilder::new()
+///     .content_bytes(file_bytes[0..10_000].to_vec())
+///     .fixed_chunker(1024) // Generate lots of small blocks
+///     .degree(4)
+///     .build()?
+///     .store(&server_store)
+///     .await?;
+/// # Ok(())
+/// # }
+/// ```
+///
+/// ### With Streaming
+///
+/// This simulates a pull protocol run between two peers locally:
+///
+/// ```
+/// use car_mirror::{pull, common::Config};
+/// use futures::TryStreamExt;
+/// use tokio_util::io::StreamReader;
+/// # use car_mirror::cache::InMemoryCache;
+/// # use wnfs_common::MemoryBlockStore;
+/// # use wnfs_unixfs_file::builder::FileBuilder;
+/// #
+/// # #[async_std::main]
+/// # async fn main() -> anyhow::Result<()> {
+/// # let client_store = MemoryBlockStore::new();
+/// # let server_store = MemoryBlockStore::new();
+/// #
+/// # let client_cache = InMemoryCache::new(100_000);
+/// # let server_cache = InMemoryCache::new(100_000);
+/// #
+/// # let file_bytes = async_std::fs::read("../Cargo.lock").await?;
+/// #
+/// # let root = FileBuilder::new()
+/// #     .content_bytes(file_bytes.clone())
+/// #     .fixed_chunker(1024) // Generate lots of small blocks
+/// #     .degree(4)
+/// #     .build()?
+/// #     .store(&client_store)
+/// #     .await?;
+/// #
+/// # FileBuilder::new()
+/// #     .content_bytes(file_bytes[0..10_000].to_vec())
+/// #     .fixed_chunker(1024) // Generate lots of small blocks
+/// #     .degree(4)
+/// #     .build()?
+/// #     .store(&server_store)
+/// #     .await?;
+///
+/// // We set up some protocol configurations (allowed maximum block sizes etc.)
+/// let config = &Config::default();
+///
+/// // The client generates a request of what data still needs to be fetched
+/// let mut request =
+///     pull::request(root, None, config, &client_store, &client_cache).await?;
+///
+/// // The request contains information about which blocks still need to be
+/// // fetched, so we can use it to find out whether we need to to fetch any
+/// // blocks at all.
+/// while !request.indicates_finished() {
+///     // The server answers with a stream of data
+///     let chunk_stream = pull::response_streaming(
+///         root,
+///         request,
+///         &server_store,
+///         &server_cache
+///     ).await?;
+///
+///     let byte_stream = StreamReader::new(
+///         chunk_stream.map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e)),
+///     );
+///
+///     // The client verifies & stores the streamed data and possibly
+///     // interrupts the stream to produce a new request with more precise
+///     // information on what to pull.
+///     request = pull::handle_response_streaming(
+///         root,
+///         byte_stream,
+///         config,
+///         &client_store,
+///         &client_cache,
+///     ).await?;
+/// }
+/// # Ok(())
+/// # }
+/// ```
+///
+///
+/// ### Without Streaming
+///
+/// This simulates a pull protocol run between two peers locally, without streaming:
+///
+/// ```
+/// use car_mirror::{pull, common::Config};
+/// # use car_mirror::cache::InMemoryCache;
+/// # use wnfs_common::MemoryBlockStore;
+/// # use wnfs_unixfs_file::builder::FileBuilder;
+/// #
+/// # #[async_std::main]
+/// # async fn main() -> anyhow::Result<()> {
+/// # let client_store = MemoryBlockStore::new();
+/// # let server_store = MemoryBlockStore::new();
+/// #
+/// # let client_cache = InMemoryCache::new(100_000);
+/// # let server_cache = InMemoryCache::new(100_000);
+/// #
+/// # let file_bytes = async_std::fs::read("../Cargo.lock").await?;
+/// #
+/// # let root = FileBuilder::new()
+/// #     .content_bytes(file_bytes.clone())
+/// #     .fixed_chunker(1024) // Generate lots of small blocks
+/// #     .degree(4)
+/// #     .build()?
+/// #     .store(&client_store)
+/// #     .await?;
+/// #
+/// # FileBuilder::new()
+/// #     .content_bytes(file_bytes[0..10_000].to_vec())
+/// #     .fixed_chunker(1024) // Generate lots of small blocks
+/// #     .degree(4)
+/// #     .build()?
+/// #     .store(&server_store)
+/// #     .await?;
+///
+/// // We set up some protocol configurations (allowed maximum block sizes etc.)
+/// let config = &Config::default();
+///
+/// let mut last_car = None;
+/// loop {
+///     // The client handles a possible previous response and produces a request
+///     let request = pull::request(
+///         root,
+///         last_car,
+///         config,
+///         &client_store,
+///         &client_cache
+///     ).await?;
+///
+///     if request.indicates_finished() {
+///         break; // No need to fetch more, we already have all data
+///     }
+///
+///     // The server consumes the car file and provides information about
+///     // further blocks needed
+///     last_car = Some(pull::response(
+///         root,
+///         request,
+///         config,
+///         &server_store,
+///         &server_cache
+///     ).await?);
+/// }
+/// # Ok(())
+/// # }
+/// ```
 pub mod pull;
 /// The CAR mirror push protocol. Meant to be used qualified, i.e. `push::request` and `push::response`.
 ///
@@ -53,8 +247,6 @@ pub mod pull;
 /// use car_mirror::cache::InMemoryCache;
 /// use wnfs_common::MemoryBlockStore;
 /// use wnfs_unixfs_file::builder::FileBuilder;
-/// use futures::TryStreamExt;
-/// use tokio_util::io::StreamReader;
 ///
 /// # #[async_std::main]
 /// # async fn main() -> anyhow::Result<()> {
@@ -97,11 +289,11 @@ pub mod pull;
 ///
 /// ```
 /// use car_mirror::{push, common::Config};
+/// use futures::TryStreamExt;
+/// use tokio_util::io::StreamReader;
 /// # use car_mirror::cache::InMemoryCache;
 /// # use wnfs_common::MemoryBlockStore;
 /// # use wnfs_unixfs_file::builder::FileBuilder;
-/// # use futures::TryStreamExt;
-/// # use tokio_util::io::StreamReader;
 /// #
 /// # #[async_std::main]
 /// # async fn main() -> anyhow::Result<()> {
@@ -135,7 +327,7 @@ pub mod pull;
 /// let mut last_response = None;
 /// loop {
 ///     // The client generates a request that streams the data to the server
-///     let stream = push::request_streaming(
+///     let chunk_stream = push::request_streaming(
 ///         root,
 ///         last_response,
 ///         &client_store,
@@ -143,7 +335,7 @@ pub mod pull;
 ///     ).await?;
 ///
 ///     let byte_stream = StreamReader::new(
-///         stream.map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e)),
+///         chunk_stream.map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e)),
 ///     );
 ///
 ///     // The server consumes the streaming request & interrupts with new
@@ -177,8 +369,6 @@ pub mod pull;
 /// # use car_mirror::cache::InMemoryCache;
 /// # use wnfs_common::MemoryBlockStore;
 /// # use wnfs_unixfs_file::builder::FileBuilder;
-/// # use futures::TryStreamExt;
-/// # use tokio_util::io::StreamReader;
 /// #
 /// # #[async_std::main]
 /// # async fn main() -> anyhow::Result<()> {

--- a/car-mirror/src/lib.rs
+++ b/car-mirror/src/lib.rs
@@ -58,7 +58,7 @@ pub mod messages;
 /// let client_store = MemoryBlockStore::new();
 /// let server_store = MemoryBlockStore::new();
 ///
-/// // Give both peers ~1MB of cache space for speeding up computations.
+/// // Give both peers ~10MB of cache space for speeding up computations.
 /// // These are available under the `quick_cache` feature.
 /// // (You can also implement your own, or disable caches using `NoCache`)
 /// let client_cache = InMemoryCache::new(100_000);
@@ -254,7 +254,7 @@ pub mod pull;
 /// let client_store = MemoryBlockStore::new();
 /// let server_store = MemoryBlockStore::new();
 ///
-/// // Give both peers ~1MB of cache space for speeding up computations.
+/// // Give both peers ~10MB of cache space for speeding up computations.
 /// // These are available under the `quick_cache` feature.
 /// // (You can also implement your own, or disable caches using `NoCache`)
 /// let client_cache = InMemoryCache::new(100_000);

--- a/car-mirror/src/lib.rs
+++ b/car-mirror/src/lib.rs
@@ -2,7 +2,14 @@
 #![warn(missing_debug_implementations, missing_docs, rust_2018_idioms)]
 #![deny(unreachable_pub)]
 
-//! car-mirror
+//! # Car Mirror
+//!
+//! This crate provides the "no-io" protocol pieces to run the car mirror protocol.
+//!
+//! For more information, see the `push` and `pull` modules for further documentation
+//! or take a look at the [specification].
+//!
+//! [specification]: https://github.com/wnfs-wg/car-mirror-spec
 
 /// Test utilities. Enabled with the `test_utils` feature flag.
 #[cfg(any(test, feature = "test_utils"))]
@@ -11,19 +18,227 @@ pub mod test_utils;
 
 /// Module with local caching strategies and mechanisms that greatly enhance CAR mirror performance
 pub mod cache;
-/// Common utilities
+/// Code that's common among the push and pull protocol sides (most of the code).
+///
+/// This code is less concerened about the "client" and "server" ends of the protocol, but
+/// more about the "block sending" and "block receiving" end of the protocol. I.e. which
+/// direction do blocks go?
+/// When going from "push" to "pull" protocol, the client and server swap the "block sending"
+/// and "block receiving" roles.
+///
+/// Consider the functions in here mostly internal, and refer to the `push` and `pull` modules instead.
 pub mod common;
 /// Algorithms for walking IPLD directed acyclic graphs
 pub mod dag_walk;
 /// Error types
 mod error;
-/// Algorithms for doing incremental verification of IPLD DAGs on the receiving end.
+/// Algorithms for doing incremental verification of IPLD DAGs against a root hash on the receiving end.
 pub mod incremental_verification;
 /// Data types that are sent over-the-wire and relevant serialization code.
 pub mod messages;
-/// The CAR mirror pull protocol. Meant to be used qualified, i.e. `pull::request` and `pull::response`
+/// The CAR mirror pull protocol. Meant to be used qualified, i.e. `pull::request` and `pull::response`.
 pub mod pull;
-/// The CAR mirror push protocol. Meant to be used qualified, i.e. `push::request` and `push::response`
+/// The CAR mirror push protocol. Meant to be used qualified, i.e. `push::request` and `push::response`.
+///
+/// This library exposes both streaming and non-streaming variants. It's recommended to use
+/// the streaming variants if possible.
+///
+/// ## Examples
+///
+/// ### Test Data
+///
+/// We'll set up some test data to simulate the protocol like this:
+///
+/// ```no_run
+/// use car_mirror::cache::InMemoryCache;
+/// use wnfs_common::MemoryBlockStore;
+/// use wnfs_unixfs_file::builder::FileBuilder;
+/// use futures::TryStreamExt;
+/// use tokio_util::io::StreamReader;
+///
+/// # #[async_std::main]
+/// # async fn main() -> anyhow::Result<()> {
+/// // We simulate peers having separate data stores
+/// let client_store = MemoryBlockStore::new();
+/// let server_store = MemoryBlockStore::new();
+///
+/// // Give both peers ~1MB of cache space for speeding up computations.
+/// // These are available under the `quick_cache` feature.
+/// // (You can also implement your own, or disable caches using `NoCache`)
+/// let client_cache = InMemoryCache::new(100_000);
+/// let server_cache = InMemoryCache::new(100_000);
+///
+/// let file_bytes = async_std::fs::read("../Cargo.lock").await?;
+///
+/// // Load some data onto the client
+/// let root = FileBuilder::new()
+///     .content_bytes(file_bytes.clone())
+///     .fixed_chunker(1024) // Generate lots of small blocks
+///     .degree(4)
+///     .build()?
+///     .store(&client_store)
+///     .await?;
+///
+/// // The server may already have a subset of the data
+/// FileBuilder::new()
+///     .content_bytes(file_bytes[0..10_000].to_vec())
+///     .fixed_chunker(1024) // Generate lots of small blocks
+///     .degree(4)
+///     .build()?
+///     .store(&server_store)
+///     .await?;
+/// # Ok(())
+/// # }
+/// ```
+///
+/// ### With Streaming
+///
+/// This simulates a push protocol run between two peers locally:
+///
+/// ```
+/// use car_mirror::{push, common::Config};
+/// # use car_mirror::cache::InMemoryCache;
+/// # use wnfs_common::MemoryBlockStore;
+/// # use wnfs_unixfs_file::builder::FileBuilder;
+/// # use futures::TryStreamExt;
+/// # use tokio_util::io::StreamReader;
+/// #
+/// # #[async_std::main]
+/// # async fn main() -> anyhow::Result<()> {
+/// # let client_store = MemoryBlockStore::new();
+/// # let server_store = MemoryBlockStore::new();
+/// #
+/// # let client_cache = InMemoryCache::new(100_000);
+/// # let server_cache = InMemoryCache::new(100_000);
+/// #
+/// # let file_bytes = async_std::fs::read("../Cargo.lock").await?;
+/// #
+/// # let root = FileBuilder::new()
+/// #     .content_bytes(file_bytes.clone())
+/// #     .fixed_chunker(1024) // Generate lots of small blocks
+/// #     .degree(4)
+/// #     .build()?
+/// #     .store(&client_store)
+/// #     .await?;
+/// #
+/// # FileBuilder::new()
+/// #     .content_bytes(file_bytes[0..10_000].to_vec())
+/// #     .fixed_chunker(1024) // Generate lots of small blocks
+/// #     .degree(4)
+/// #     .build()?
+/// #     .store(&server_store)
+/// #     .await?;
+///
+/// // We set up some protocol configurations (allowed maximum block sizes etc.)
+/// let config = &Config::default();
+///
+/// let mut last_response = None;
+/// loop {
+///     // The client generates a request that streams the data to the server
+///     let stream = push::request_streaming(
+///         root,
+///         last_response,
+///         &client_store,
+///         &client_cache
+///     ).await?;
+///
+///     let byte_stream = StreamReader::new(
+///         stream.map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e)),
+///     );
+///
+///     // The server consumes the streaming request & interrupts with new
+///     // information about what blocks it already has or in case the client
+///     // can stop sending altogether.
+///     let response = push::response_streaming(
+///         root,
+///         byte_stream,
+///         config,
+///         &server_store,
+///         &server_cache
+///     ).await?;
+///
+///     if response.indicates_finished() {
+///         break; // we're done!
+///     }
+///
+///     last_response = Some(response);
+/// }
+/// # Ok(())
+/// # }
+/// ```
+///
+///
+/// ### Without Streaming
+///
+/// This simulates a push protocol run between two peers locally, without streaming:
+///
+/// ```
+/// use car_mirror::{push, common::Config};
+/// # use car_mirror::cache::InMemoryCache;
+/// # use wnfs_common::MemoryBlockStore;
+/// # use wnfs_unixfs_file::builder::FileBuilder;
+/// # use futures::TryStreamExt;
+/// # use tokio_util::io::StreamReader;
+/// #
+/// # #[async_std::main]
+/// # async fn main() -> anyhow::Result<()> {
+/// # let client_store = MemoryBlockStore::new();
+/// # let server_store = MemoryBlockStore::new();
+/// #
+/// # let client_cache = InMemoryCache::new(100_000);
+/// # let server_cache = InMemoryCache::new(100_000);
+/// #
+/// # let file_bytes = async_std::fs::read("../Cargo.lock").await?;
+/// #
+/// # let root = FileBuilder::new()
+/// #     .content_bytes(file_bytes.clone())
+/// #     .fixed_chunker(1024) // Generate lots of small blocks
+/// #     .degree(4)
+/// #     .build()?
+/// #     .store(&client_store)
+/// #     .await?;
+/// #
+/// # FileBuilder::new()
+/// #     .content_bytes(file_bytes[0..10_000].to_vec())
+/// #     .fixed_chunker(1024) // Generate lots of small blocks
+/// #     .degree(4)
+/// #     .build()?
+/// #     .store(&server_store)
+/// #     .await?;
+///
+/// // We set up some protocol configurations (allowed maximum block sizes etc.)
+/// let config = &Config::default();
+///
+/// let mut last_response = None;
+/// loop {
+///     // The client creates a CAR file for the request
+///     let car_file = push::request(
+///         root,
+///         last_response,
+///         config,
+///         &client_store,
+///         &client_cache
+///     ).await?;
+///
+///     // The server consumes the car file and provides information about
+///     // further blocks needed
+///     let response = push::response(
+///         root,
+///         car_file,
+///         config,
+///         &server_store,
+///         &server_cache
+///     ).await?;
+///
+///     if response.indicates_finished() {
+///         break; // we're done!
+///     }
+///
+///     last_response = Some(response);
+/// }
+/// # Ok(())
+/// # }
+/// ```
 pub mod push;
 
 pub use error::*;

--- a/car-mirror/src/lib.rs
+++ b/car-mirror/src/lib.rs
@@ -16,7 +16,7 @@ pub mod common;
 /// Algorithms for walking IPLD directed acyclic graphs
 pub mod dag_walk;
 /// Error types
-pub mod error;
+mod error;
 /// Algorithms for doing incremental verification of IPLD DAGs on the receiving end.
 pub mod incremental_verification;
 /// Data types that are sent over-the-wire and relevant serialization code.
@@ -25,3 +25,5 @@ pub mod messages;
 pub mod pull;
 /// The CAR mirror push protocol. Meant to be used qualified, i.e. `push::request` and `push::response`
 pub mod push;
+
+pub use error::*;

--- a/car-mirror/src/pull.rs
+++ b/car-mirror/src/pull.rs
@@ -80,16 +80,18 @@ pub async fn response_streaming<'a>(
 #[cfg(test)]
 mod tests {
     use crate::{
-        cache::NoCache,
+        cache::{InMemoryCache, NoCache},
         common::Config,
         dag_walk::DagWalk,
-        test_utils::{setup_random_dag, Metrics},
+        pull,
+        test_utils::{setup_random_dag, store_test_unixfs, Metrics},
     };
     use anyhow::Result;
     use futures::TryStreamExt;
     use libipld::Cid;
     use std::collections::HashSet;
     use testresult::TestResult;
+    use tokio_util::io::StreamReader;
     use wnfs_common::{BlockStore, MemoryBlockStore};
 
     pub(crate) async fn simulate_protocol(
@@ -99,11 +101,10 @@ mod tests {
         server_store: &impl BlockStore,
     ) -> Result<Vec<Metrics>> {
         let mut metrics = Vec::new();
-        let mut request = crate::pull::request(root, None, config, client_store, &NoCache).await?;
+        let mut request = pull::request(root, None, config, client_store, &NoCache).await?;
         while !request.indicates_finished() {
             let request_bytes = serde_ipld_dagcbor::to_vec(&request)?.len();
-            let response =
-                crate::pull::response(root, request, config, server_store, NoCache).await?;
+            let response = pull::response(root, request, config, server_store, NoCache).await?;
             let response_bytes = response.bytes.len();
 
             metrics.push(Metrics {
@@ -111,8 +112,7 @@ mod tests {
                 response_bytes,
             });
 
-            request =
-                crate::pull::request(root, Some(response), config, client_store, &NoCache).await?;
+            request = pull::request(root, Some(response), config, client_store, &NoCache).await?;
         }
 
         Ok(metrics)
@@ -141,6 +141,43 @@ mod tests {
 
         Ok(())
     }
+
+    #[test_log::test(async_std::test)]
+    async fn test_streaming_transfer() -> TestResult {
+        let client_store = MemoryBlockStore::new();
+        let server_store = MemoryBlockStore::new();
+
+        let client_cache = InMemoryCache::new(100_000);
+        let server_cache = InMemoryCache::new(100_000);
+
+        let file_bytes = async_std::fs::read("../Cargo.lock").await?;
+        let root = store_test_unixfs(file_bytes.clone(), &client_store).await?;
+        store_test_unixfs(file_bytes[0..10_000].to_vec(), &server_store).await?;
+
+        let config = &Config::default();
+
+        let mut request = pull::request(root, None, config, &client_store, &client_cache).await?;
+
+        while !request.indicates_finished() {
+            let car_stream =
+                pull::response_streaming(root, request, &server_store, &server_cache).await?;
+
+            let byte_stream = StreamReader::new(
+                car_stream.map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e)),
+            );
+
+            request = pull::handle_response_streaming(
+                root,
+                byte_stream,
+                config,
+                &client_store,
+                &client_cache,
+            )
+            .await?;
+        }
+
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -149,6 +186,7 @@ mod proptests {
         cache::NoCache,
         common::Config,
         dag_walk::DagWalk,
+        pull,
         test_utils::{setup_blockstore, variable_blocksize_dag},
     };
     use futures::TryStreamExt;
@@ -164,14 +202,9 @@ mod proptests {
             let server_store = &setup_blockstore(blocks).await.unwrap();
             let client_store = &MemoryBlockStore::new();
 
-            crate::pull::tests::simulate_protocol(
-                root,
-                &Config::default(),
-                client_store,
-                server_store,
-            )
-            .await
-            .unwrap();
+            pull::tests::simulate_protocol(root, &Config::default(), client_store, server_store)
+                .await
+                .unwrap();
 
             // client should have all data
             let client_cids = DagWalk::breadth_first([root])

--- a/car-mirror/src/pull.rs
+++ b/car-mirror/src/pull.rs
@@ -21,7 +21,7 @@ use wnfs_common::{utils::CondSend, BlockStore};
 ///
 /// Before actually sending the request over the network,
 /// make sure to check the `request.indicates_finished()`.
-/// If true, the client already has all data and the request
+/// If true, the "client" already has all data and the request
 /// doesn't need to be sent.
 pub async fn request(
     root: Cid,
@@ -35,7 +35,10 @@ pub async fn request(
         .into())
 }
 
-/// TODO(matheus23): DOCS
+/// On the "client" side, handle a streaming response from a pull request.
+///
+/// This will accept blocks as long as they're useful to get the DAG under
+/// `root`, verify them, and store them in the given `store`.
 pub async fn handle_response_streaming(
     root: Cid,
     stream: impl AsyncRead + Unpin + CondSend,
@@ -48,7 +51,7 @@ pub async fn handle_response_streaming(
         .into())
 }
 
-/// Respond to a CAR mirror pull request.
+/// Respond to a CAR mirror pull request on the "server" side.
 pub async fn response(
     root: Cid,
     request: PullRequest,
@@ -60,7 +63,9 @@ pub async fn response(
     block_send(root, receiver_state, config, store, cache).await
 }
 
-/// TODO(matheus23): DOCS
+/// On the "server" side, respond to a pull request with a stream.
+///
+/// This can especially speed up cold pull requests.
 pub async fn response_streaming<'a>(
     root: Cid,
     request: PullRequest,

--- a/car-mirror/src/push.rs
+++ b/car-mirror/src/push.rs
@@ -1,14 +1,14 @@
 use crate::{
     cache::Cache,
     common::{
-        block_receive, block_send, block_send_block_stream, stream_car_frames, CarFile, CarStream,
-        Config, ReceiverState,
+        block_receive, block_receive_car_stream, block_send, block_send_block_stream,
+        stream_car_frames, CarFile, CarStream, Config, ReceiverState,
     },
     error::Error,
     messages::PushResponse,
 };
 use libipld_core::cid::Cid;
-use wnfs_common::BlockStore;
+use wnfs_common::{utils::CondSend, BlockStore};
 
 /// Create a CAR mirror push request.
 ///
@@ -62,6 +62,21 @@ pub async fn response(
     Ok(block_receive(root, Some(request), config, store, cache)
         .await?
         .into())
+}
+
+/// TODO(matheus23): DOCS
+pub async fn response_streaming(
+    root: Cid,
+    request: impl tokio::io::AsyncRead + Unpin + CondSend,
+    config: &Config,
+    store: impl BlockStore,
+    cache: impl Cache,
+) -> Result<PushResponse, Error> {
+    Ok(
+        block_receive_car_stream(root, request, config, store, cache)
+            .await?
+            .into(),
+    )
 }
 
 #[cfg(test)]

--- a/car-mirror/src/push.rs
+++ b/car-mirror/src/push.rs
@@ -31,7 +31,11 @@ pub async fn request(
     block_send(root, receiver_state, config, store, cache).await
 }
 
-/// TODO(matheus23): DOCS
+/// Streaming version of `request` to create a push request.
+///
+/// It's recommended to run the streaming push until the "server" interrupts
+/// it with an updated `PushResponse`. Then continuing with another
+/// push request with updated information.
 pub async fn request_streaming<'a>(
     root: Cid,
     last_response: Option<PushResponse>,
@@ -50,7 +54,7 @@ pub async fn request_streaming<'a>(
 /// in the given `store`, if the blocks can be shown to relate
 /// to the `root` CID.
 ///
-/// Returns a response that gives the client information about what
+/// Returns a response that gives the "client" information about what
 /// other data remains to be fetched.
 pub async fn response(
     root: Cid,
@@ -64,7 +68,12 @@ pub async fn response(
         .into())
 }
 
-/// TODO(matheus23): DOCS
+/// Respond to a push request on the "server" side in a streaming fashing
+/// (as opposed to the `response` function).
+///
+/// This will read from the `request` until the server realizes it got
+/// some bytes it already had. Then it'll create an updated bloom filter
+/// and send a `PushResponse`, interrupting the incoming stream.
 pub async fn response_streaming(
     root: Cid,
     request: impl tokio::io::AsyncRead + Unpin + CondSend,

--- a/car-mirror/src/test_utils/local_utils.rs
+++ b/car-mirror/src/test_utils/local_utils.rs
@@ -94,3 +94,13 @@ pub(crate) async fn total_dag_blocks(root: Cid, store: &impl BlockStore) -> Resu
 }
 
 pub(crate) fn assert_cond_send_sync<T: CondSend>(_fut: fn() -> T) {}
+
+pub(crate) async fn store_test_unixfs(data: Vec<u8>, store: &impl BlockStore) -> Result<Cid> {
+    wnfs_unixfs_file::builder::FileBuilder::new()
+        .content_bytes(data)
+        .fixed_chunker(1024) // Generate lots of small blocks
+        .degree(4)
+        .build()?
+        .store(store)
+        .await
+}

--- a/deny.toml
+++ b/deny.toml
@@ -77,6 +77,7 @@ allow = [
     "BSD-3-Clause",
     "ISC",
     "Zlib",
+    "MPL-2.0",
     "BSL-1.0"
 ]
 # List of explicitly disallowed licenses


### PR DESCRIPTION
## TODO

- [x] Documentation for `pull::handle_request_streaming` and `push::request_streaming`
- [x] Module-level doctests in `car-mirror` to show how the request loop works
- [x] Module-level doctests in `car-mirror-reqwest` to show how to make a request against a simple axum server (this turned into a compilation doctest & the axum example instead)